### PR TITLE
[i,l,-r] build: bump version to 2.3.0-wavemm.1

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0</version>
+  <version>2.3.0-wavemm.1</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>


### PR DESCRIPTION
Bumps Maven version to mark this as a wavemm fork build (distinct from upstream 2.3.0).

Also serves a practical purpose: our App Engine `version_id` is derived from the source ZIP hash, and App Engine doesn't allow mutating env vars on an existing version. When we flip env-var-only settings (e.g., `SLACK_NOTIFICATIONS_ENABLED`) without touching Java source, Terraform tries to delete-and-recreate a version with the same ID, which App Engine rejects with 409.

Bumping the trailing patch (.1, .2, .3, ...) on every flag-only redeploy is cheap and gives an unambiguous progression in the App Engine version list. The next env-var-only redeploy will bump to `2.3.0-wavemm.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)