### PR TITLE
[i,l,-r] fix(slack): @Singleton producer, exclude requester, log root causes

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0-wavemm.1</version>
+  <version>2.3.0-wavemm.2</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -267,6 +267,7 @@ public class Application {
   }
 
   @Produces
+  @Singleton
   public @NotNull ProposalHandler produceProposalHandler(
     @NotNull TokenSigner tokenSigner,
     @NotNull SecretManagerClient secretManagerClient,

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
@@ -117,6 +117,13 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     var reviewerEmails = expanded.stream()
       .filter(EndUserId.class::isInstance)
       .map(p -> ((EndUserId) p).email)
+      // Drop the requester from the expanded reviewer set. The upstream
+      // `JoinOperation.propose` filter excludes the requester at *principal*
+      // level (group ≠ user), so when the policy ACL names a group that the
+      // requester also belongs to (the typical "team approves team" pattern),
+      // the requester sneaks back in after group expansion. Without this we'd
+      // DM the requester their own approval request.
+      .filter(email -> !email.equalsIgnoreCase(beneficiary))
       .distinct()
       .sorted()
       .toList();
@@ -138,8 +145,34 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     @NotNull ProposalHandler.ProposalToken token,
     @NotNull URI actionUri
   ) throws AccessException, IOException {
-    var fp = fingerprint(proposal);
+    RegistryFingerprint fp;
+    try {
+      fp = fingerprint(proposal);
+    }
+    catch (AccessException e) {
+      // Surface the underlying cause; AbstractProposalHandler will wrap
+      // this into AccessDeniedException("Creating a proposal failed", e)
+      // which the user sees as a 403 with no detail. Logging here makes
+      // sure the actual reason (typically a Cloud Identity Groups API
+      // permission gap) is visible in Cloud Logging.
+      this.logger.error(
+        "slack.fingerprint.failed",
+        "Resolving reviewers via GroupResolver failed for requester=%s "
+          + "group=%s — likely a Cloud Identity Groups API permission gap "
+          + "on the JIT service account.",
+        proposal.user().email,
+        proposal.group().toString(),
+        e);
+      throw e;
+    }
+
     if (fp.reviewerEmails().isEmpty()) {
+      this.logger.error(
+        "slack.noReviewers",
+        "Group %s expanded to zero individual users (after excluding the "
+          + "requester %s). Either the policy ACL is misconfigured or the "
+          + "approver group has no listable members.",
+        fp.groupId(), fp.beneficiary());
       throw new IOException(
         "No qualified reviewers resolved to individual users for " + fp.groupId());
     }
@@ -192,6 +225,13 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     }
 
     if (posted.isEmpty()) {
+      this.logger.error(
+        "slack.allDmsFailed",
+        "Slack DM delivery failed for every one of %d reviewer(s) on %s. "
+          + "See preceding slack.dm.failed entries for the per-reviewer "
+          + "cause (typical: missing Slack scope, invalid bot token, or "
+          + "user not in the workspace).",
+        fp.reviewerEmails().size(), fp.groupId());
       throw new IOException(
         "Slack DM delivery failed for every reviewer (" + fp.reviewerEmails().size()
           + ") on " + fp.groupId());


### PR DESCRIPTION
Four small fixes from the first end-to-end test on the staged App Engine version (\`rev-c2f171f7a17f0f51\`).

## What was happening

User submitted MPA on \`0-test-mpa-flow\` → JIT UI showed \`HTTP 403: error\`. Logs revealed:

\`\`\`
Failed to DM reviewer adam.rapley@wave.com for jit-group:production.gcp.0-test-mpa-flow:
users.lookupByEmail failed: missing_scope
\`\`\`

Root cause was a missing Slack scope (\`users:read.email\`) on the bot — fixed out-of-band (added scope, reinstalled, rotated Secret Manager). But the bug surfaced three pieces of latent bad behaviour worth fixing.

## Fixes

### 1. \`produceProposalHandler\` is now \`@Singleton\`

Was \`@Dependent\` (CDI default), so every request rebuilt the factory output — including a fresh \`Firestore\` client + gRPC \`ManagedChannel\`. Each abandoned channel surfaced as an ERROR-severity \`ManagedChannel allocation site\` stack trace in stderr when gRPC's leak detector fired. \`@Singleton\` = one construction per JVM, no leak.

### 2. Filter the requester out of the expanded reviewer set

\`JoinOperation.propose\` drops the requester at the *principal* level (group ≠ user). When the policy ACL names a group that the requester is in (\`0-test-mpa-flow\` is exactly this — security ↔ security), the requester re-appears after \`GroupResolver.expand\`. They'd get a DM about their own request. Filter post-expansion with case-insensitive email match.

### 3. Log root causes before re-throwing in \`onOperationProposed\`

\`AbstractProposalHandler.propose\` catches \`AccessException | IOException\` and re-throws a generic \`AccessDeniedException(\"Creating a proposal failed\", e)\` → 403 in the UI with no detail. The first E2E test hit Slack 403 \`missing_scope\` — per-reviewer \`slack.dm.failed\` log captured the symptom, but the \`IOException(\"Slack DM delivery failed for every reviewer\")\` that propagated up was silent. Add explicit error logs at the three throw sites:
- \`slack.fingerprint.failed\` (AccessException from GroupResolver — typical: missing Cloud Identity perms)
- \`slack.noReviewers\` (zero individuals after expansion — typical: misconfigured policy)
- \`slack.allDmsFailed\` (every per-reviewer DM failed — typical: missing Slack scope, bad token)

### 4. Bump pom version to \`2.3.0-wavemm.2\`

Forces a new App Engine \`version_id\` on the next deploy, so the rotated bot token (with \`users:read.email\` scope added) actually takes effect. App Engine doesn't allow mutating env vars on an existing version + our \`version_id\` is derived from the source ZIP hash + same-id replace = 409 → we keep bumping the trailing patch.

## Test plan

- [x] \`mvn test\` (CI on this PR).
- [ ] After merge + wavemm-iam submodule bump + apply: re-submit \`0-test-mpa-flow\` on the new versioned URL. Expected: DMs to Adam + Alex (not Lorenzo himself), one approves, sibling DM updates, beneficiary confirmation DM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)