### PR TITLE
[i,l,-r] Phase 2b/3 + security hardening: reviewer picker UX + opt-out copy-link

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0-wavemm.5</version>
+  <version>2.3.0-wavemm.6</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
@@ -206,6 +206,41 @@
             <phase>test</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <!--
+          Wavemm fork P2-13: OWASP dependency-check. Surfaces known CVEs
+          in our (mostly Google-owned) transitive dep tree as part of
+          the Maven build so a CVE that lands in slack-api-client,
+          google-cloud-firestore, or any other dependency triggers a
+          build failure once the CVSS exceeds the configured threshold.
+
+          Run via `mvn org.owasp:dependency-check-maven:check` in CI or
+          locally; not bound to a default phase to keep `mvn test` fast.
+          A reviewer who runs the standard test target (`mvn -DskipITs
+          test`) won't pay the NVD-feed download cost.
+        -->
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>11.1.1</version>
+        <configuration>
+          <!-- Fail the build on CVSS >= 8 (high+). Lower-severity CVEs
+               surface in the report but don't break CI; we triage them
+               through the regular dependency-bump cadence. -->
+          <failBuildOnCVSS>8</failBuildOnCVSS>
+          <suppressionFiles>
+            <!-- Optional suppression file — created if/when we need to
+                 silence a reviewed-and-acknowledged finding. Absent by
+                 default; the plugin tolerates a missing file. -->
+            <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
+          </suppressionFiles>
+          <!-- Skip unused analyzers to shorten a CI run from ~5 min
+               to ~2 min on a warm cache. -->
+          <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+          <nodeAuditAnalyzerEnabled>false</nodeAuditAnalyzerEnabled>
+          <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
+          <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0-wavemm.2</version>
+  <version>2.3.0-wavemm.5</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>

--- a/sources/src/main/java/com/google/solutions/jitaccess/auth/GroupResolver.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/auth/GroupResolver.java
@@ -36,8 +36,57 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 /**
- * Expands group memberships using the Cloud Identity
- * Groups API.
+ * Expands group memberships using the Cloud Identity Groups API.
+ *
+ * <p><b>Visibility &amp; trust boundary (wavemm fork P1-7).</b> The
+ * output of {@link #expand} is a flat set of {@link EndUserId}/{@link
+ * GroupId} principals derived from policy-ACL-supplied group ids. It
+ * is NOT itself an authorisation decision — it answers the question
+ * "who are the (one-level-resolved) members of these groups?", nothing
+ * more. Callers that use it to populate audit fields, message
+ * recipients, or picker candidate lists are fine; callers that use it
+ * to decide whether a specific principal can perform a privileged
+ * action MUST cross-check against the policy ACL, because:
+ *
+ * <ul>
+ *   <li>resolution is one level deep (nested groups are not flattened
+ *       — see method comment), so the absence of a user from
+ *       {@code expand(...)} does NOT prove they aren't an effective
+ *       member;</li>
+ *   <li>an empty/failed Cloud Identity response is silently equivalent
+ *       to "no members" inside this method (the per-group lambda in
+ *       {@link com.google.solutions.jitaccess.web.proposal.ReviewerCandidates}
+ *       turns errors into empty lists for picker robustness; do not
+ *       copy that pattern when correctness matters);</li>
+ *   <li>service-account members of approver groups are silently
+ *       dropped (see {@link #principalFromMembership}), so any
+ *       authorisation decision derived from {@code expand} must also
+ *       account for non-EndUser principals via the policy ACL
+ *       directly.</li>
+ * </ul>
+ *
+ * <p><b>Audit of in-tree callers</b> (re-verify when adding a new
+ * one):
+ *
+ * <ul>
+ *   <li>{@link com.google.solutions.jitaccess.web.rest.GroupsResource#post}
+ *       — selectedReviewers subset check: combines {@code expand} with
+ *       a separate ACL lookup, NOT a sole authorisation source. ✓
+ *   <li>{@link com.google.solutions.jitaccess.web.rest.GroupsResource#getReviewers}
+ *       — picker candidate listing: best-effort, output is for UX
+ *       only. ✓
+ *   <li>{@link com.google.solutions.jitaccess.web.proposal.ReviewerCandidates#compute}
+ *       — picker UI: same as above. ✓
+ *   <li>{@link com.google.solutions.jitaccess.web.proposal.SlackProposalHandler#fingerprint}
+ *       — registry key + DM dispatch: NOT an authorisation source;
+ *       the JWT verified by {@code JitGroupContext.approve} is. ✓
+ * </ul>
+ *
+ * <p>Any new caller that uses {@code expand} for an authorisation
+ * decision must add itself here AND ensure a separate ACL check is
+ * still performed. The catalog-side defense in {@link
+ * com.google.solutions.jitaccess.catalog.JitGroupContext.JoinOperation#propose(java.time.Instant,
+ * java.util.Set)} is the trust-boundary backstop that catches a forgotten check.
  */
 public class GroupResolver {
   private final @NotNull CloudIdentityGroupsClient groupsClient;

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
@@ -29,6 +29,7 @@ import com.google.solutions.jitaccess.auth.*;
 import com.google.solutions.jitaccess.catalog.policy.*;
 import com.google.solutions.jitaccess.catalog.provisioning.Provisioner;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -327,6 +328,47 @@ public class JitGroupContext {
     public @NotNull Proposal propose(
       @NotNull Instant expiry
     ) throws AccessException {
+      return propose(expiry, null);
+    }
+
+    /**
+     * Propose this operation for someone else to approve, optionally
+     * narrowing the set of recipients.
+     *
+     * <p>The picker UX (added in the wavemm fork) lets the requester
+     * choose specific reviewers rather than blasting every qualified
+     * peer. When {@code reviewerFilter} is non-null, the recipient set
+     * REPLACES the policy-derived qualified set with the filter — group
+     * principals from the ACL are dropped so the picker doesn't get
+     * defeated by post-handler group expansion.
+     *
+     * <p>When {@code reviewerFilter} is null the behaviour is identical
+     * to the upstream single-arg {@link #propose(Instant)} method.
+     *
+     * <p><b>SECURITY:</b> the caller is responsible for verifying that
+     * every {@code EndUserId} in {@code reviewerFilter} is actually in
+     * the expanded set of authorised approvers BEFORE invoking this
+     * method. This trust boundary lives at the REST layer
+     * ({@code GroupsResource.post}) where {@link
+     * com.google.solutions.jitaccess.auth.GroupResolver} is available
+     * to expand groups; doing it here would force the catalog package
+     * to depend on Cloud Identity, which is the wrong layering.
+     *
+     * <p>Today {@code GroupsResource.post} is the only caller exercising
+     * the filter path. <b>Any new caller MUST replicate the
+     * subset-validation</b> via {@link
+     * com.google.solutions.jitaccess.web.proposal.ReviewerCandidates}
+     * (or equivalent) — otherwise a hostile {@code reviewerFilter}
+     * could trick this method into producing a JWT naming arbitrary
+     * principals as recipients. (The JWT is not the authoritative
+     * approval check — {@code JitGroupContext.approve} re-evaluates
+     * the policy ACL — but reviewer identity does flow into audit
+     * logs, sibling Slack updates, and copy-link distribution.)
+     */
+    public @NotNull Proposal propose(
+      @NotNull Instant expiry,
+      @Nullable Set<EndUserId> reviewerFilter
+    ) throws AccessException {
       if (!this.requiresApproval) {
         throw new IllegalStateException(
           "The join operation does not require approval and cannot be proposed");
@@ -362,6 +404,40 @@ public class JitGroupContext {
           "There are no principals that could approve the request to join this group");
       }
 
+      //
+      // Apply the requester-supplied filter, if any.
+      //
+      // When a filter is set, it REPLACES the policy-derived approvers
+      // set with the requester's selection. We deliberately don't keep
+      // GroupId entries from the original ACL alongside the filtered
+      // EndUserIds — otherwise a typical Wave ACL of
+      // {group:engineering_platform_security@} would let the group
+      // pass through unchanged, the SlackProposalHandler would expand
+      // it back to every member, and the picker would be a UX lie
+      // (user selects "only Adam", every team-mate gets DM'd anyway).
+      //
+      // The REST layer (GroupsResource) is responsible for validating
+      // that every email in the filter is in the expanded qualified-
+      // peer set BEFORE calling propose — see ReviewerCandidates and
+      // the validation step in GroupsResource.post. By the time we
+      // get here the filter is trusted to be a subset of authorised
+      // approvers, so we can short-circuit straight to the filter.
+      //
+      Set<IamPrincipalId> filteredApprovers;
+      if (reviewerFilter == null || reviewerFilter.isEmpty()) {
+        filteredApprovers = approvers;
+      } else {
+        filteredApprovers = reviewerFilter.stream()
+          .map(u -> (IamPrincipalId) u)
+          .collect(Collectors.toSet());
+      }
+
+      if (filteredApprovers.isEmpty()) {
+        throw new AccessDeniedException(
+          "None of the selected reviewers are authorised to approve this request");
+      }
+
+      var finalApprovers = filteredApprovers;
       return new Proposal() {
         @Override
         public @NotNull EndUserId user() {
@@ -375,7 +451,7 @@ public class JitGroupContext {
 
         @Override
         public @NotNull Set<IamPrincipalId> recipients() {
-          return approvers;
+          return finalApprovers;
         }
 
         @Override

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/JitGroupContext.java
@@ -345,25 +345,27 @@ public class JitGroupContext {
      * <p>When {@code reviewerFilter} is null the behaviour is identical
      * to the upstream single-arg {@link #propose(Instant)} method.
      *
-     * <p><b>SECURITY:</b> the caller is responsible for verifying that
-     * every {@code EndUserId} in {@code reviewerFilter} is actually in
-     * the expanded set of authorised approvers BEFORE invoking this
-     * method. This trust boundary lives at the REST layer
+     * <p><b>SECURITY (defense-in-depth, wavemm fork P1-6):</b> the catalog
+     * enforces what it can locally — every {@code EndUserId} in the
+     * filter must either appear directly in the policy ACL, OR the ACL
+     * must contain at least one {@link GroupId} approver into which the
+     * caller has already verified the filter expands. The full subset-
+     * after-group-expansion check still lives at the REST layer
      * ({@code GroupsResource.post}) where {@link
-     * com.google.solutions.jitaccess.auth.GroupResolver} is available
-     * to expand groups; doing it here would force the catalog package
-     * to depend on Cloud Identity, which is the wrong layering.
+     * com.google.solutions.jitaccess.auth.GroupResolver} is available;
+     * forcing the catalog to depend on Cloud Identity would be the
+     * wrong layering. But a future caller that forgets the REST-layer
+     * check still cannot smuggle in a principal who has no chance of
+     * being a real approver — the catalog rejects filter entries that
+     * are not in the direct ACL and have no group approver to
+     * conceivably belong to.
      *
-     * <p>Today {@code GroupsResource.post} is the only caller exercising
-     * the filter path. <b>Any new caller MUST replicate the
-     * subset-validation</b> via {@link
-     * com.google.solutions.jitaccess.web.proposal.ReviewerCandidates}
-     * (or equivalent) — otherwise a hostile {@code reviewerFilter}
-     * could trick this method into producing a JWT naming arbitrary
-     * principals as recipients. (The JWT is not the authoritative
-     * approval check — {@code JitGroupContext.approve} re-evaluates
-     * the policy ACL — but reviewer identity does flow into audit
-     * logs, sibling Slack updates, and copy-link distribution.)
+     * <p>This is a partial defense: an ACL of
+     * {@code group:engineering@} still allows the catalog to honour a
+     * filter naming any email (because the email <i>could</i> be in
+     * the group, and the catalog can't tell from here). The REST
+     * layer's expansion check is what closes that gap — see {@link
+     * com.google.solutions.jitaccess.web.proposal.ReviewerCandidates}.
      */
     public @NotNull Proposal propose(
       @NotNull Instant expiry,
@@ -418,15 +420,40 @@ public class JitGroupContext {
       //
       // The REST layer (GroupsResource) is responsible for validating
       // that every email in the filter is in the expanded qualified-
-      // peer set BEFORE calling propose — see ReviewerCandidates and
-      // the validation step in GroupsResource.post. By the time we
-      // get here the filter is trusted to be a subset of authorised
-      // approvers, so we can short-circuit straight to the filter.
+      // peer set BEFORE calling propose. The defense-in-depth check
+      // below catches the case where a future caller forgets that
+      // step — we reject filter entries that are not in the direct
+      // ACL when the ACL has no group approvers, since in that case
+      // the catalog has full visibility into who's authorised.
       //
       Set<IamPrincipalId> filteredApprovers;
       if (reviewerFilter == null || reviewerFilter.isEmpty()) {
         filteredApprovers = approvers;
       } else {
+        var directAclEndUsers = approvers.stream()
+          .filter(EndUserId.class::isInstance)
+          .map(EndUserId.class::cast)
+          .collect(Collectors.toSet());
+        var aclHasGroupApprover = approvers.stream()
+          .anyMatch(GroupId.class::isInstance);
+
+        // Reject filter entries the catalog can prove are not
+        // authorised. If the ACL has no group approver every entry
+        // must be in directAclEndUsers; if there's a group approver
+        // we can't prove it without expansion, so we trust the REST
+        // layer's check (which has run, modulo a calling-code bug).
+        if (!aclHasGroupApprover) {
+          var bogus = reviewerFilter.stream()
+            .filter(u -> !directAclEndUsers.contains(u))
+            .map(u -> u.email)
+            .toList();
+          if (!bogus.isEmpty()) {
+            throw new AccessDeniedException(
+              "Selected reviewers are not authorised to approve this "
+                + "request: " + String.join(", ", bogus));
+          }
+        }
+
         filteredApprovers = reviewerFilter.stream()
           .map(u -> (IamPrincipalId) u)
           .collect(Collectors.toSet());

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/Proposal.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/Proposal.java
@@ -59,6 +59,35 @@ public interface Proposal {
   @NotNull Map<String, String> input();
 
   /**
+   * Wavemm fork: whether the requester opted in to having the proposal
+   * handler deliver out-of-band notification (Slack DMs / email) to
+   * reviewers, vs. opting out to copy and share the approval URL
+   * manually.
+   *
+   * <p>When false:
+   * <ul>
+   *   <li>{@code AbstractProposalHandler.propose} skips the
+   *       {@code onOperationProposed} hook — no DMs, no Firestore
+   *       registry entry.
+   *   <li>{@code SlackProposalHandler.onProposalApproved} short-
+   *       circuits the sibling-update path (there are no siblings to
+   *       update because no DMs were sent), keeping only the
+   *       beneficiary-confirmation DM. The previous "no Slack
+   *       registry entry" warning becomes a routine INFO log.
+   * </ul>
+   *
+   * <p>The flag is encoded as a JWT claim so it survives the
+   * propose → accept round-trip and the approver doesn't need to
+   * re-derive the requester's intent from the request side.
+   *
+   * <p>Default: {@code true}, matching upstream behaviour where
+   * notification is always attempted.
+   */
+  default boolean notifyReviewers() {
+    return true;
+  }
+
+  /**
    * Invoked when the proposal was completed successfully.
    */
   void onCompleted(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -297,12 +297,13 @@ public class Application {
       // and no DM goes out.
       //
       if (configuration.slackBotTokenSecret.isEmpty()
-        || configuration.slackFirestoreDatabase.isEmpty()) {
+        || configuration.slackFirestoreDatabase.isEmpty()
+        || configuration.slackRegistryKeySaltSecret.isEmpty()) {
         throw new IllegalStateException(
-          "SLACK_NOTIFICATIONS_ENABLED=true requires both SLACK_BOT_TOKEN_SECRET "
-            + "and SLACK_FIRESTORE_DATABASE. Either provide them or set "
-            + "SLACK_NOTIFICATIONS_ENABLED=false to restore the upstream "
-            + "notification path.");
+          "SLACK_NOTIFICATIONS_ENABLED=true requires SLACK_BOT_TOKEN_SECRET, "
+            + "SLACK_FIRESTORE_DATABASE, and SLACK_REGISTRY_KEY_SALT_SECRET. "
+            + "Either provide them or set SLACK_NOTIFICATIONS_ENABLED=false "
+            + "to restore the upstream notification path.");
       }
 
       try {
@@ -311,6 +312,19 @@ public class Application {
         if (botToken == null || botToken.isBlank()) {
           throw new IllegalStateException(
             "SLACK_BOT_TOKEN_SECRET points to an empty secret value");
+        }
+
+        //
+        // Wavemm fork P2-11: HMAC salt for SlackMessageRegistry document
+        // keys. Read at the same lifecycle point as the bot token so a
+        // misconfigured (missing/empty) salt fails app startup loudly,
+        // not silently at the first elevation request.
+        //
+        var registryKeySalt = secretManagerClient.accessSecret(
+          configuration.slackRegistryKeySaltSecret.get());
+        if (registryKeySalt == null || registryKeySalt.isBlank()) {
+          throw new IllegalStateException(
+            "SLACK_REGISTRY_KEY_SALT_SECRET points to an empty secret value");
         }
 
         //
@@ -329,7 +343,8 @@ public class Application {
           .getService();
 
         var slackClient = new SlackClient(botToken, executor, logger);
-        var registry = new SlackMessageRegistry(firestore, executor, logger);
+        var registry = new SlackMessageRegistry(
+          firestore, executor, logger, registryKeySalt);
         var groupResolver = new GroupResolver(groupsClient, executor);
 
         return new SlackProposalHandler(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/Application.java
@@ -220,6 +220,13 @@ public class Application {
   }
 
   @Produces
+  @Singleton
+  public com.google.solutions.jitaccess.web.rest.GroupsResource.Options produceGroupsResourceOptions() {
+    return new com.google.solutions.jitaccess.web.rest.GroupsResource.Options(
+      configuration.slackCopyLinkEnabled);
+  }
+
+  @Produces
   public GoogleCredentials produceApplicationCredentials() {
     return runtime.applicationCredentials();
   }
@@ -391,7 +398,8 @@ public class Application {
         @Override
         public @NotNull ProposalHandler.ProposalToken propose(
           @NotNull JitGroupContext.JoinOperation joinOperation,
-          @NotNull Function<String, URI> buildActionUri
+          @NotNull Function<String, URI> buildActionUri,
+          @NotNull ProposalHandler.ProposeOptions options
           ) {
           throw new UnsupportedOperationException(
             "Approvals are not supported because the SMTP configuration is incomplete");

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApplicationConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApplicationConfiguration.java
@@ -198,6 +198,19 @@ public class ApplicationConfiguration extends AbstractConfiguration {
   final @NotNull Optional<String> slackFirestoreDatabase;
 
   /**
+   * Secret Manager resource path of the HMAC salt used to compute the
+   * registry document key (wavemm fork P2-11). Required when
+   * {@link #slackNotificationsEnabled} is true. Format:
+   * projects/X/secrets/Y/versions/Z. The salt MUST stay constant for
+   * the lifetime of any in-flight JWT — rotating it strands open
+   * approval requests because the propose-time and accept-time keys
+   * stop matching. Rotate during a quiet period (e.g. between
+   * deploys) and follow the secret-rotation runbook in
+   * SLACK_INTEGRATION.md.
+   */
+  final @NotNull Optional<String> slackRegistryKeySaltSecret;
+
+  /**
    * When true, the {@code POST /api/.../groups/{name}} response includes
    * the JWT-bearing approval URL so the requester can copy it manually,
    * and the form accepts {@code notifyReviewers=false} to skip the
@@ -335,6 +348,7 @@ public class ApplicationConfiguration extends AbstractConfiguration {
       .orElse(false);
     this.slackBotTokenSecret = readStringSetting("SLACK_BOT_TOKEN_SECRET");
     this.slackFirestoreDatabase = readStringSetting("SLACK_FIRESTORE_DATABASE");
+    this.slackRegistryKeySaltSecret = readStringSetting("SLACK_REGISTRY_KEY_SALT_SECRET");
     this.slackCopyLinkEnabled = readSetting(
       Boolean::parseBoolean, "SLACK_COPY_LINK_ENABLED")
       .orElse(false);

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/ApplicationConfiguration.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/ApplicationConfiguration.java
@@ -197,6 +197,17 @@ public class ApplicationConfiguration extends AbstractConfiguration {
    */
   final @NotNull Optional<String> slackFirestoreDatabase;
 
+  /**
+   * When true, the {@code POST /api/.../groups/{name}} response includes
+   * the JWT-bearing approval URL so the requester can copy it manually,
+   * and the form accepts {@code notifyReviewers=false} to skip the
+   * automated Slack DM delivery entirely (the JWT is still generated and
+   * signed). Independent of {@link #slackNotificationsEnabled} —
+   * disabling this flag just hides the affordance; Slack DMs continue to
+   * fire as long as Slack is configured.
+   */
+  final boolean slackCopyLinkEnabled;
+
   public ApplicationConfiguration(@NotNull Map<String, String> settingsData) {
     super(settingsData);
 
@@ -324,6 +335,9 @@ public class ApplicationConfiguration extends AbstractConfiguration {
       .orElse(false);
     this.slackBotTokenSecret = readStringSetting("SLACK_BOT_TOKEN_SECRET");
     this.slackFirestoreDatabase = readStringSetting("SLACK_FIRESTORE_DATABASE");
+    this.slackCopyLinkEnabled = readSetting(
+      Boolean::parseBoolean, "SLACK_COPY_LINK_ENABLED")
+      .orElse(false);
   }
 
   public boolean isSmtpConfigured() {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/OperationAuditTrail.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/OperationAuditTrail.java
@@ -52,6 +52,18 @@ public class OperationAuditTrail {
   static final String LABEL_PROPOSAL_RECIPIENTS = "proposal/recipients";
   static final String LABEL_EVENT_TYPE = "event/type";
 
+  /**
+   * Wavemm fork P1-8: distinguishes the regular "DM the qualified
+   * peer set" propose path from the opt-out copy-link path
+   * ({@code notifyReviewers=false}). Both stay under the same
+   * {@code api.groups.join} event id so existing log-based BigQuery
+   * dashboards keep counting them; the new label is what lets a
+   * security analyst slice "approval requests not visible to the
+   * normal reviewer set" — those flow only via the JWT URL the
+   * requester pastes into another channel.
+   */
+  static final String LABEL_PROPOSAL_NOTIFY_REVIEWERS = "proposal/notify_reviewers";
+
   public OperationAuditTrail(@NotNull Logger logger) {
     this.logger = logger;
   }
@@ -73,29 +85,60 @@ public class OperationAuditTrail {
     }
   }
 
+  /**
+   * Backwards-compatible single-arg overload. Defaults
+   * {@code notifyReviewers=true} to match upstream behaviour — every
+   * pre-fork caller assumed reviewers were notified by the proposal
+   * handler.
+   */
   public void joinProposed(
     @NotNull JitGroupContext.JoinOperation joinOp,
     @NotNull ProposalHandler.ProposalToken proposal
   ) {
+    joinProposed(joinOp, proposal, true);
+  }
+
+  /**
+   * Audit-log a proposed join.
+   *
+   * @param notifyReviewers wavemm fork P1-8/P2-10 — false means the
+   *                        requester opted out of automated reviewer
+   *                        notifications and intends to forward the
+   *                        approval URL out-of-band via copy-link.
+   *                        Surfaced as {@link
+   *                        #LABEL_PROPOSAL_NOTIFY_REVIEWERS} so the
+   *                        security log sink can distinguish the two
+   *                        flows; the message body is also tweaked so
+   *                        humans grepping the log see "via copy-link"
+   *                        for the opt-out case.
+   */
+  public void joinProposed(
+    @NotNull JitGroupContext.JoinOperation joinOp,
+    @NotNull ProposalHandler.ProposalToken proposal,
+    boolean notifyReviewers
+  ) {
+    var recipients = proposal.audience()
+      .stream()
+      .map(IamPrincipalId::toString)
+      .sorted()
+      .toList();
     this.logger.buildInfo(EventIds.API_JOIN_GROUP)
       .addLabel(LABEL_EVENT_TYPE, "audit")
       .addLabel(LABEL_GROUP_ID, joinOp.group())
-      .addLabel(LABEL_PROPOSAL_RECIPIENTS, proposal.audience()
-        .stream()
-        .map(IamPrincipalId::toString)
-        .sorted()
-        .collect(Collectors.joining(",")))
+      .addLabel(LABEL_PROPOSAL_RECIPIENTS, String.join(",", recipients))
+      .addLabel(LABEL_PROPOSAL_NOTIFY_REVIEWERS, Boolean.toString(notifyReviewers))
       .addLabels(joinOp.input()
         .stream()
         .collect(Collectors.toMap(i -> LABEL_PREFIX_JOIN_INPUT + i.name(), i -> i.get())))
       .setMessage(
-        "User '%s' asked to join group '%s', proposed to %s for approval",
+        notifyReviewers
+          ? "User '%s' asked to join group '%s', proposed to %s for approval"
+          : "User '%s' asked to join group '%s', approval URL issued via "
+              + "copy-link (notifyReviewers=false); reviewers %s were authorised "
+              + "but NOT auto-notified",
         joinOp.user(),
         joinOp.group(),
-        proposal.audience()
-          .stream()
-          .map(IamPrincipalId::toString)
-          .sorted()
+        recipients.stream()
           .map(MoreStrings::quote)
           .collect(Collectors.joining(", ")))
       .write();

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/AbstractProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/AbstractProposalHandler.java
@@ -83,11 +83,13 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
   @Override
   public @NotNull ProposalHandler.ProposalToken propose(
     @NotNull JitGroupContext.JoinOperation joinOperation,
-    @NotNull Function<String, URI> buildActionUri
+    @NotNull Function<String, URI> buildActionUri,
+    @NotNull ProposeOptions options
   ) throws AccessException {
 
     var proposal = joinOperation.propose(
-      Instant.now().plus(this.options.tokenExpiry));
+      Instant.now().plus(this.options.tokenExpiry),
+      options.reviewerFilter());
 
     Preconditions.checkArgument(
       !proposal.recipients().isEmpty(),
@@ -118,6 +120,16 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
       .set(Claims.USER_ID, proposal.user().toString())
       .set(Claims.INPUT, inputs);
 
+    //
+    // Wavemm fork: encode the notify-reviewers flag in the JWT only when
+    // the requester opted out. Default-on means we don't pollute every
+    // existing token with a redundant claim, and the accept() path
+    // treats absence as the upstream "true" default.
+    //
+    if (!options.notifyReviewers()) {
+      payload.set(Claims.NOTIFY, Boolean.FALSE);
+    }
+
     try {
       var signedToken = this.tokenSigner.sign(
         payload,
@@ -127,11 +139,19 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
         proposal.recipients(),
         signedToken.expiryTime());
 
-      onOperationProposed(
-        joinOperation,
-        proposal,
-        proposalToken,
-        buildActionUri.apply(proposalToken.value()));
+      //
+      // Skip notification delivery when the caller opted out — the JWT
+      // is still generated, signed, and returned, so the requester can
+      // copy/share the action URL manually (e.g. send to a specific
+      // reviewer in Slack DM themselves).
+      //
+      if (options.notifyReviewers()) {
+        onOperationProposed(
+          joinOperation,
+          proposal,
+          proposalToken,
+          buildActionUri.apply(proposalToken.value()));
+      }
 
       return proposalToken;
     }
@@ -174,6 +194,12 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
       .stream()
       .collect(Collectors.toMap(e -> e.getKey(), e-> (String)e.getValue()));
 
+    // Wavemm fork: read the opt-out claim. Absent or true → default
+    // upstream behaviour; explicit false → requester chose to share
+    // the link manually, no DMs were sent at propose-time.
+    var notifyClaim = payload.get(Claims.NOTIFY);
+    final boolean notifyReviewers = !(notifyClaim instanceof Boolean && !((Boolean) notifyClaim));
+
     return new Proposal() {
       @Override
       public @NotNull EndUserId user() {
@@ -201,6 +227,11 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
       }
 
       @Override
+      public boolean notifyReviewers() {
+        return notifyReviewers;
+      }
+
+      @Override
       public void onCompleted(
         @NotNull JitGroupContext.ApprovalOperation op
       ) throws AccessException, IOException {
@@ -214,6 +245,10 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
     static final String GROUP_ID = "grp";
     static final String USER_ID = "usr";
     static final String INPUT = "inp";
+    /** Wavemm fork: only present when the requester opted out of
+     *  automated reviewer notification. Absence means the upstream
+     *  default — notify reviewers — applies. */
+    static final String NOTIFY = "ntf";
   }
 
   public record Options(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ProposalHandler.java
@@ -22,10 +22,12 @@
 package com.google.solutions.jitaccess.web.proposal;
 
 import com.google.solutions.jitaccess.apis.clients.AccessException;
+import com.google.solutions.jitaccess.auth.EndUserId;
 import com.google.solutions.jitaccess.auth.IamPrincipalId;
 import com.google.solutions.jitaccess.catalog.JitGroupContext;
 import com.google.solutions.jitaccess.catalog.Proposal;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.time.Instant;
@@ -40,10 +42,48 @@ public interface ProposalHandler {
    * Express the intent to join a group and solicit approval
    * from an authorized user.
    */
-  @NotNull ProposalHandler.ProposalToken propose(
+  default @NotNull ProposalHandler.ProposalToken propose(
     @NotNull JitGroupContext.JoinOperation joinOperation,
     @NotNull Function<String, URI> buildActionUri
+  ) throws AccessException {
+    return propose(joinOperation, buildActionUri, ProposeOptions.DEFAULT);
+  }
+
+  /**
+   * Variant accepting per-request options:
+   * <ul>
+   *   <li>{@link ProposeOptions#reviewerFilter()} — narrow the set of
+   *       qualified peers to a subset selected by the requester (the
+   *       picker UX in the wavemm fork). Null = no filter.
+   *   <li>{@link ProposeOptions#notifyReviewers()} — when false, the
+   *       handler skips out-of-band notification (Slack DMs / email) but
+   *       still generates and signs the JWT, returning the
+   *       {@link ProposalToken} to the caller. Used by the "copy
+   *       approval link" flow where the requester shares the link
+   *       manually.
+   * </ul>
+   */
+  @NotNull ProposalHandler.ProposalToken propose(
+    @NotNull JitGroupContext.JoinOperation joinOperation,
+    @NotNull Function<String, URI> buildActionUri,
+    @NotNull ProposeOptions options
   ) throws AccessException;
+
+  /**
+   * Per-request options for {@link #propose}.
+   *
+   * @param reviewerFilter when non-null, narrows the recipients to
+   *                       individuals selected by the requester
+   * @param notifyReviewers when false, the proposal token is generated
+   *                        but no Slack/email notification is delivered
+   */
+  record ProposeOptions(
+    @Nullable Set<EndUserId> reviewerFilter,
+    boolean notifyReviewers
+  ) {
+    public static final @NotNull ProposeOptions DEFAULT =
+      new ProposeOptions(null, true);
+  }
 
   /**
    * Accept a proposal.

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ReviewerCandidates.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ReviewerCandidates.java
@@ -1,0 +1,286 @@
+//
+// Copyright 2026 Wave Mobile Money / wavemm fork
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+
+package com.google.solutions.jitaccess.web.proposal;
+
+import com.google.api.services.cloudidentity.v1.model.Membership;
+import com.google.solutions.jitaccess.apis.clients.AccessException;
+import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
+import com.google.solutions.jitaccess.auth.EndUserId;
+import com.google.solutions.jitaccess.auth.GroupId;
+import com.google.solutions.jitaccess.auth.GroupResolver;
+import com.google.solutions.jitaccess.auth.IamPrincipalId;
+import com.google.solutions.jitaccess.auth.PrincipalId;
+import com.google.solutions.jitaccess.common.CompletableFutures;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/**
+ * Computes the candidate-reviewer list shown in the picker UI when a
+ * requester is about to submit an MPA elevation.
+ *
+ * <p>Two outputs per call:
+ * <ul>
+ *   <li>The full list of qualified peer reviewers (after group
+ *       expansion, excluding the requester).
+ *   <li>A {@code suggested} flag per candidate indicating whether they
+ *       are likely to be on the requester's team — defined as sharing
+ *       at least one small {@code *@roles.wave.com} group with the
+ *       requester (regardless of whether that group is in the policy
+ *       ACL).
+ * </ul>
+ *
+ * <p>"Small enough" is what makes the heuristic tractable: a broad
+ * group like {@code engineering@} (hundreds of members) is a poor
+ * signal of "team", so we skip groups exceeding {@link
+ * #SUGGESTION_GROUP_MAX_SIZE}. Team groups (typically &lt;15 members
+ * per Wave's org chart) survive.
+ *
+ * <p>Algorithm:
+ * <ol>
+ *   <li>{@link CloudIdentityGroupsClient#listMembershipsByUser} on the
+ *       requester to find every group they belong to (not just
+ *       approver groups).
+ *   <li>Fetch each group's members in parallel via {@link
+ *       CompletableFutures#mapAsync} so 10 small groups cost ~one
+ *       round-trip wallclock instead of ten. Groups whose membership
+ *       exceeds the size cap are skipped after the fetch.
+ *   <li>Tally how many requester-groups each candidate co-inhabits;
+ *       higher overlap → stronger team signal. Top {@link
+ *       #SUGGESTED_BADGE_TOP_N} get the badge.
+ * </ol>
+ *
+ * <p>The candidate list itself is computed independently by expanding
+ * the policy-ACL principals — same code path as the SlackProposalHandler
+ * uses for DM delivery, ensuring consistency between picker and
+ * dispatch.
+ */
+public class ReviewerCandidates {
+  /**
+   * A group with more than this many direct members is treated as
+   * "broad" (e.g. {@code engineering@}) and not used as a team-mate
+   * signal. Cap is intentionally generous — the typical Wave team
+   * is &lt;15, but cross-team initiatives can reach the low tens.
+   */
+  static final int SUGGESTION_GROUP_MAX_SIZE = 30;
+
+  /**
+   * Hard cap on the number of candidates the suggested badge is
+   * rendered for in the UI. The caller (the GET /reviewers handler)
+   * still returns the full candidate list; the badge is what
+   * highlights the top-N teammates.
+   */
+  static final int SUGGESTED_BADGE_TOP_N = 3;
+
+  private final @NotNull GroupResolver groupResolver;
+  private final @NotNull CloudIdentityGroupsClient groupsClient;
+  private final @NotNull Executor executor;
+
+  public ReviewerCandidates(
+    @NotNull GroupResolver groupResolver,
+    @NotNull CloudIdentityGroupsClient groupsClient,
+    @NotNull Executor executor
+  ) {
+    this.groupResolver = groupResolver;
+    this.groupsClient = groupsClient;
+    this.executor = executor;
+  }
+
+  /**
+   * Compute the candidate list for a given (requester, qualified-peers)
+   * tuple.
+   *
+   * @param requester the user making the elevation request
+   * @param qualifiedPeers the union of principals (EndUserId + GroupId)
+   *                       holding APPROVE_OTHERS in the policy ACL
+   * @return suggested-first, alphabetically-then list of candidates
+   */
+  public @NotNull List<Candidate> compute(
+    @NotNull EndUserId requester,
+    @NotNull Set<IamPrincipalId> qualifiedPeers
+  ) throws AccessException, IOException {
+    //
+    // Step 1: expand any GroupId in the qualified peers to individual
+    // EndUserIds so the picker shows actual people, not groups.
+    //
+    Set<PrincipalId> expandedAcl = this.groupResolver.expand(
+      new HashSet<>(qualifiedPeers));
+
+    Set<EndUserId> individualCandidates = expandedAcl.stream()
+      .filter(EndUserId.class::isInstance)
+      .map(p -> (EndUserId) p)
+      .filter(u -> !u.equals(requester))  // never list the requester
+      .collect(Collectors.toSet());
+
+    if (individualCandidates.isEmpty()) {
+      return List.of();
+    }
+
+    //
+    // Step 2: rank candidates by team-mate likelihood.
+    //
+    Map<EndUserId, Integer> teamScore = computeTeamScores(
+      requester, individualCandidates);
+
+    //
+    // Order candidates: those with a non-zero team score come first
+    // (highest score wins ties), then everyone else alphabetically.
+    // The badge applies only to the top N from the score-ranked
+    // subset to avoid surfacing dozens of teammates if the requester
+    // is in many small overlapping groups.
+    //
+    var ranked = individualCandidates.stream()
+      .sorted(Comparator
+        .comparingInt((EndUserId u) ->
+          -teamScore.getOrDefault(u, 0))     // higher score first
+        .thenComparing(u -> u.email))
+      .toList();
+
+    Set<EndUserId> badgeSet = ranked.stream()
+      .filter(u -> teamScore.getOrDefault(u, 0) > 0)
+      .limit(SUGGESTED_BADGE_TOP_N)
+      .collect(Collectors.toSet());
+
+    return ranked.stream()
+      .map(u -> new Candidate(
+        u.email,
+        u.email,  // displayName: same as email until we wire Directory.users.get
+        badgeSet.contains(u)))
+      .toList();
+  }
+
+  /**
+   * Fetch each requester-group's members in parallel and tally how
+   * many groups each candidate co-inhabits. Skips groups exceeding
+   * the size cap so broad memberships like {@code engineering@} don't
+   * dilute the signal.
+   *
+   * <p>Calls {@link CloudIdentityGroupsClient#listMemberships} directly
+   * (one parallel batch via {@link CompletableFutures#mapAsync})
+   * instead of routing through {@link GroupResolver#expand} per-group,
+   * which would serialise 10 round-trips at 200 ms each into a
+   * 2-second blocking call on the picker page.
+   */
+  private @NotNull Map<EndUserId, Integer> computeTeamScores(
+    @NotNull EndUserId requester,
+    @NotNull Set<EndUserId> candidates
+  ) throws AccessException, IOException {
+    var requesterGroups = this.groupsClient
+      .listMembershipsByUser(requester)
+      .stream()
+      .map(rel -> rel.getGroupKey())
+      .filter(key -> key != null && key.getId() != null)
+      .map(key -> new GroupId(key.getId()))
+      .toList();
+
+    if (requesterGroups.isEmpty()) {
+      return Map.of();
+    }
+
+    //
+    // Parallel fan-out: kick off every listMemberships call at once
+    // and join the lot. Per-group failures are turned into empty
+    // results inside the lambda so one bad group (deleted, permission
+    // hiccup) doesn't poison the entire suggestion computation.
+    //
+    var future = CompletableFutures.mapAsync(
+      requesterGroups,
+      group -> {
+        try {
+          return new GroupMembers(group, this.groupsClient.listMemberships(group));
+        }
+        catch (Exception e) {
+          return new GroupMembers(group, List.of());
+        }
+      },
+      this.executor);
+
+    Collection<GroupMembers> all;
+    try {
+      all = future.get();
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Map.of();
+    }
+    catch (ExecutionException e) {
+      // mapAsync wraps individual failures, but our lambda already
+      // catches them. An ExecutionException here means something
+      // truly unexpected; degrade rather than blow up the picker.
+      return Map.of();
+    }
+
+    var scores = new HashMap<EndUserId, Integer>();
+    for (var gm : all) {
+      // Skip broad groups — engineering@ has hundreds of members and
+      // sharing it with the requester says nothing about being on
+      // their team.
+      if (gm.members().size() > SUGGESTION_GROUP_MAX_SIZE) {
+        continue;
+      }
+
+      gm.members().stream()
+        .map(ReviewerCandidates::endUserOrNull)
+        .filter(u -> u != null)
+        .filter(candidates::contains)
+        .forEach(c -> scores.merge(c, 1, Integer::sum));
+    }
+    return scores;
+  }
+
+  /**
+   * Convert a {@link Membership} to an {@link EndUserId}, or null if
+   * the membership isn't a user (groups, service accounts, malformed
+   * entries). Mirrors the conversion in {@code
+   * GroupResolver.principalFromMembership} but inlined to avoid going
+   * through the resolver's higher-level {@code expand} API for a
+   * call we deliberately want to parallelise ourselves.
+   */
+  private static EndUserId endUserOrNull(@NotNull Membership m) {
+    if (!EndUserId.TYPE.equalsIgnoreCase(m.getType())) {
+      return null;
+    }
+    var key = m.getPreferredMemberKey();
+    if (key == null || key.getId() == null) {
+      return null;
+    }
+    return new EndUserId(key.getId());
+  }
+
+  /** Pair of (group, fetched members) used by the parallel fan-out. */
+  private record GroupMembers(@NotNull GroupId group, @NotNull List<Membership> members) {}
+
+  /**
+   * One picker candidate — what the frontend renders as a checkbox.
+   *
+   * @param email primary email (also the JIT principal value)
+   * @param displayName presentation name; equal to email until we wire
+   *                    Directory API for actual display names
+   * @param suggested true if this candidate is in the top
+   *                  {@link #SUGGESTED_BADGE_TOP_N} ranked teammates
+   *                  (rendered with the "team" badge in the UI)
+   */
+  public record Candidate(
+    @NotNull String email,
+    @NotNull String displayName,
+    boolean suggested
+  ) {}
+}

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessageRegistry.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessageRegistry.java
@@ -18,8 +18,10 @@ import com.google.solutions.jitaccess.apis.Logger;
 import com.google.solutions.jitaccess.common.CompletableFutures;
 import org.jetbrains.annotations.NotNull;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -44,10 +46,11 @@ import java.util.concurrent.Executor;
  *
  * <p>Storage: a named Firestore Native database in the same GCP project as
  * JIT. The collection is {@value #COLLECTION}; each document key is the
- * SHA-256 of (beneficiary, group, sorted recipient emails). Each document
- * carries a TTL field {@code expires_at} aligned with the JWT expiry; the
- * Firestore TTL policy (managed in wavemm-iam Terraform) auto-deletes
- * stale entries — best-effort, can lag up to 24h.
+ * HMAC-SHA-256 of (beneficiary, group, sorted recipient emails) under a
+ * Secret Manager-backed salt (wavemm fork P2-11). Each document carries a
+ * TTL field {@code expires_at} aligned with the JWT expiry; the Firestore
+ * TTL policy (managed in wavemm-iam Terraform) auto-deletes stale entries
+ * — best-effort, can lag up to 24h.
  */
 public class SlackMessageRegistry {
   static final String COLLECTION = "requests";
@@ -58,14 +61,35 @@ public class SlackMessageRegistry {
   private final @NotNull Executor executor;
   private final @NotNull Logger logger;
 
+  /**
+   * HMAC key bytes for the registry-document fingerprint. Read once at
+   * startup from Secret Manager via {@code SLACK_REGISTRY_KEY_SALT_SECRET}
+   * and held in memory for the JVM lifetime — same lifecycle as the
+   * Slack bot token.
+   *
+   * <p>Without the HMAC the registry document key would be a plain
+   * SHA-256 of inputs that an attacker who reads {@code (beneficiary,
+   * group, recipient)} tuples can guess (e.g. via leaked logs or a
+   * compromised audit pipeline). HMAC-ing under a secret salt means
+   * an attacker without {@code roles/secretmanager.secretAccessor} on
+   * the salt secret can't enumerate registry contents even with
+   * Firestore read access.
+   */
+  private final byte @NotNull [] hmacKey;
+
   public SlackMessageRegistry(
     @NotNull Firestore firestore,
     @NotNull Executor executor,
-    @NotNull Logger logger
+    @NotNull Logger logger,
+    @NotNull String hmacKeySalt
   ) {
+    Preconditions.checkArgument(
+      !hmacKeySalt.isBlank(),
+      "hmacKeySalt must not be blank — set SLACK_REGISTRY_KEY_SALT_SECRET");
     this.firestore = firestore;
     this.executor = executor;
     this.logger = logger;
+    this.hmacKey = hmacKeySalt.getBytes(StandardCharsets.UTF_8);
   }
 
   private @NotNull CollectionReference collection() {
@@ -87,8 +111,17 @@ public class SlackMessageRegistry {
    * <p>Justification is intentionally excluded (large, unstable). Time
    * fields are excluded because they have second-precision drift between
    * propose and accept.
+   *
+   * <p>Wavemm fork P2-11: HMAC-SHA-256 under {@link #hmacKey} replaces
+   * the previous bare SHA-256, so an attacker without secret-manager
+   * access can't recover the key from leaked input tuples. The output
+   * shape (hex string) is unchanged so existing Firestore documents
+   * remain reachable for in-flight requests across the upgrade — but
+   * note that the salt MUST stay constant across propose and accept
+   * for a given JWT, otherwise the lookup misses and sibling DMs
+   * silently won't be updated.
    */
-  public static @NotNull String requestKey(
+  public @NotNull String requestKey(
     @NotNull String beneficiary,
     @NotNull String groupId,
     @NotNull List<String> recipientEmails
@@ -99,13 +132,20 @@ public class SlackMessageRegistry {
       groupId,
       String.join(",", sorted));
     try {
-      var digest = MessageDigest.getInstance("SHA-256")
-        .digest(canonical.getBytes(StandardCharsets.UTF_8));
+      var mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(this.hmacKey, "HmacSHA256"));
+      var digest = mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8));
       return HexFormat.of().formatHex(digest);
     }
     catch (NoSuchAlgorithmException e) {
-      // SHA-256 is mandatory in every JRE.
-      throw new AssertionError("SHA-256 not available", e);
+      // HmacSHA256 is mandatory in every JRE.
+      throw new AssertionError("HmacSHA256 not available", e);
+    }
+    catch (InvalidKeyException e) {
+      // We only construct this with a non-blank salt, so this should
+      // be impossible — surface as a hard failure so a future change
+      // that introduces a bad key is caught immediately.
+      throw new AssertionError("HMAC key rejected by Mac.init", e);
     }
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
@@ -84,8 +84,23 @@ final class SlackMessages {
       ))
       .build());
 
+    //
+    // SECURITY: justification is rendered as PLAIN TEXT, not mrkdwn.
+    // Slack's mrkdwn supports <!here>, <!channel>, <@user>, <url|text>,
+    // *bold*, etc. — and there is NO escape mechanism for these tokens.
+    // A requester pasting "<!here> URGENT: approve" into the
+    // justification field would otherwise mass-ping every reviewer's
+    // Slack workspace and could spoof links inside the approval DM.
+    // Rendering as PlainTextObject neutralises every formatting token
+    // because Slack treats those blocks as literal text. The "Justification"
+    // header is rendered separately as mrkdwn so the field still gets
+    // a bold label.
+    //
     blocks.add(SectionBlock.builder()
-      .text(markdown("*Justification*\n>" + escapeBlockquote(justification)))
+      .text(markdown("*Justification*"))
+      .build());
+    blocks.add(SectionBlock.builder()
+      .text(plain(truncateForBlock(justification)))
       .build());
 
     blocks.add(DividerBlock.builder().build());
@@ -175,6 +190,26 @@ final class SlackMessages {
     return String.format("Your PAM elevation for %s was approved by %s.", groupId, approverEmail);
   }
 
+  /**
+   * Block Kit text fields cap at 3000 characters; longer ones cause the
+   * entire chat.postMessage to fail with {@code invalid_blocks}. Truncate
+   * upstream so a single 40 KB justification can't DoS the approval flow
+   * for every reviewer.
+   */
+  static final int JUSTIFICATION_MAX_LENGTH = 2_500;
+
+  /** Public for the input-validation site in {@code GroupsResource.post}. */
+  public static int justificationMaxLength() {
+    return JUSTIFICATION_MAX_LENGTH;
+  }
+
+  private static @NotNull String truncateForBlock(@NotNull String s) {
+    if (s.length() <= JUSTIFICATION_MAX_LENGTH) {
+      return s;
+    }
+    return s.substring(0, JUSTIFICATION_MAX_LENGTH - 16) + "… [truncated]";
+  }
+
   // ----- helpers ---------------------------------------------------------
 
   private static @NotNull PlainTextObject plain(@NotNull String text) {
@@ -197,12 +232,6 @@ final class SlackMessages {
       return humanTime + " (~" + minutes + "m from now)";
     }
     return humanTime + " (~" + (minutes / 60) + "h " + (minutes % 60) + "m from now)";
-  }
-
-  private static @NotNull String escapeBlockquote(@NotNull String text) {
-    // Slack blockquotes use leading > on each newline. Escape pre-existing
-    // ones so a malicious justification can't inject formatting.
-    return text.replace("\n", "\n>").replace("`", "'");
   }
 
   /** Used by tests to assert specific field values without parsing JSON. */

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 
 /**
  * Proposal handler that delivers approval requests via Slack DMs instead
@@ -71,6 +73,18 @@ public class SlackProposalHandler extends AbstractProposalHandler {
   private final @NotNull Logger logger;
   private final @NotNull Options slackOptions;
 
+  /**
+   * Hard ceiling on the number of in-flight Slack API call chains during
+   * the per-reviewer fan-out in {@link #onOperationProposed}. A policy
+   * with a 200-member approver group would otherwise launch 200 parallel
+   * lookup→postMessage chains and risk tripping Slack's per-workspace
+   * Tier 4 quota (chat.postMessage ~100/min). With a Semaphore in front
+   * of each chain, peak in-flight calls are bounded regardless of how
+   * many reviewers a policy expands to. Permits are released in
+   * {@code .whenComplete} so failures don't leak the slot.
+   */
+  private final @NotNull Semaphore fanOutLimiter;
+
   public SlackProposalHandler(
     @NotNull TokenSigner tokenSigner,
     @NotNull SlackClient slackClient,
@@ -89,6 +103,7 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     this.groupResolver = groupResolver;
     this.logger = logger;
     this.slackOptions = slackOptions;
+    this.fanOutLimiter = new Semaphore(slackOptions.maxConcurrentFanOut(), /*fair*/ true);
   }
 
   /**
@@ -127,7 +142,7 @@ public class SlackProposalHandler extends AbstractProposalHandler {
       .distinct()
       .sorted()
       .toList();
-    var key = SlackMessageRegistry.requestKey(beneficiary, groupId, reviewerEmails);
+    var key = this.registry.requestKey(beneficiary, groupId, reviewerEmails);
     return new RegistryFingerprint(beneficiary, groupId, reviewerEmails, key);
   }
 
@@ -211,34 +226,60 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     // Tracking these separately means the "all failed" error message
     // tells the operator whether to fix Slack config or fix the policy.
     //
+    //
+    // Per-reviewer chains are gated through fanOutLimiter so we never
+    // have more than slackOptions.maxConcurrentFanOut() in-flight Slack
+    // API call pairs at once. A 200-member approver-group policy fans
+    // out at the cap rate instead of slamming the workspace Tier 4
+    // budget. Permits are released in .whenComplete so the slot frees
+    // even when the chain failed exceptionally.
+    //
     var perReviewerFutures = fp.reviewerEmails().stream()
-      .map(email -> this.slackClient.lookupUserByEmail(email)
-        .thenCompose(userId -> {
-          if (userId == null) {
-            this.logger.warn(
-              "slack.lookupByEmail.notFound",
-              "Reviewer %s is not in the Slack workspace; skipping",
-              email);
-            return java.util.concurrent.CompletableFuture.completedFuture(
-              new DmOutcome(email, null, ReviewerOutcome.NOT_IN_SLACK));
-          }
-          return this.slackClient.postDirectMessage(userId, blocks, fallback)
-            .thenApply(msg -> new DmOutcome(
-              email,
-              new ReviewerMessage(email, userId, msg.channelId(), msg.messageTs()),
-              ReviewerOutcome.POSTED));
-        })
-        .handle((outcome, ex) -> {
-          if (ex != null) {
-            var cause = (ex.getCause() != null) ? ex.getCause() : ex;
-            this.logger.warn(
-              "slack.dm.failed",
-              "Failed to DM reviewer %s for %s: %s",
-              email, fp.groupId(), cause.getMessage());
-            return new DmOutcome(email, null, ReviewerOutcome.API_FAILURE);
-          }
-          return outcome;
-        }))
+      .map(email -> {
+        try {
+          this.fanOutLimiter.acquire();
+        }
+        catch (InterruptedException ie) {
+          // Caller's thread was interrupted while we were holding the
+          // line; surface as a NOT_IN_SLACK-equivalent skip rather than
+          // crashing the whole propose call. The interrupt status is
+          // restored so upstream code can react.
+          Thread.currentThread().interrupt();
+          return CompletableFuture.completedFuture(
+            new DmOutcome(email, null, ReviewerOutcome.API_FAILURE));
+        }
+        return this.slackClient.lookupUserByEmail(email)
+          .thenCompose(userId -> {
+            if (userId == null) {
+              this.logger.warn(
+                "slack.lookupByEmail.notFound",
+                "Reviewer %s is not in the Slack workspace; skipping",
+                email);
+              return CompletableFuture.completedFuture(
+                new DmOutcome(email, null, ReviewerOutcome.NOT_IN_SLACK));
+            }
+            return this.slackClient.postDirectMessage(userId, blocks, fallback)
+              .thenApply(msg -> new DmOutcome(
+                email,
+                new ReviewerMessage(email, userId, msg.channelId(), msg.messageTs()),
+                ReviewerOutcome.POSTED));
+          })
+          .handle((outcome, ex) -> {
+            if (ex != null) {
+              var cause = (ex.getCause() != null) ? ex.getCause() : ex;
+              this.logger.warn(
+                "slack.dm.failed",
+                "Failed to DM reviewer %s for %s: %s",
+                email, fp.groupId(), cause.getMessage());
+              return new DmOutcome(email, null, ReviewerOutcome.API_FAILURE);
+            }
+            return outcome;
+          })
+          // Free the concurrency slot on every completion path
+          // (success, NOT_IN_SLACK, API_FAILURE). Use whenComplete so
+          // the value passes through unchanged.
+          .whenComplete((__, ___) -> this.fanOutLimiter.release());
+      })
       .toList();
 
     var posted = new ArrayList<ReviewerMessage>();
@@ -424,15 +465,44 @@ public class SlackProposalHandler extends AbstractProposalHandler {
   /**
    * Slack-specific options.
    *
-   * @param notificationTimeZone Time zone used to render expiry timestamps in DMs.
+   * @param notificationTimeZone time zone used to render expiry
+   *                             timestamps in DMs
+   * @param maxConcurrentFanOut  hard ceiling on concurrent
+   *                             {@code lookupUserByEmail+postMessage}
+   *                             chains during {@link
+   *                             #onOperationProposed}. Defaults via
+   *                             {@link #DEFAULT_MAX_CONCURRENT_FAN_OUT}
+   *                             to a value sized below Slack's Tier 4
+   *                             quota when policies have many
+   *                             reviewers; tune downward only on
+   *                             quota-pressure incidents.
    */
   public record Options(
-    @NotNull ZoneId notificationTimeZone
+    @NotNull ZoneId notificationTimeZone,
+    int maxConcurrentFanOut
   ) {
+    /**
+     * Default chosen so that even a 200-reviewer approver-group
+     * fan-out completes inside the typical request timeout while
+     * staying well under chat.postMessage Tier 4 (≈100/min/workspace
+     * sustained, with short bursts allowed). 8 in-flight × ~200 ms
+     * round-trip ≈ 40 req/s peak, settling around 1 req/s after
+     * Slack's leaky-bucket smoothing.
+     */
+    public static final int DEFAULT_MAX_CONCURRENT_FAN_OUT = 8;
+
     public Options {
       Preconditions.checkArgument(
         notificationTimeZone != null,
         "notificationTimeZone must not be null");
+      Preconditions.checkArgument(
+        maxConcurrentFanOut > 0,
+        "maxConcurrentFanOut must be > 0");
+    }
+
+    /** Convenience constructor that uses {@link #DEFAULT_MAX_CONCURRENT_FAN_OUT}. */
+    public Options(@NotNull ZoneId notificationTimeZone) {
+      this(notificationTimeZone, DEFAULT_MAX_CONCURRENT_FAN_OUT);
     }
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
@@ -189,53 +189,112 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     var fallback = SlackMessages.reviewRequestFallback(fp.beneficiary(), fp.groupId());
 
     //
-    // Resolve users + post DMs in parallel. Aggregate failures: if at least
-    // one DM lands, the approval flow is viable, so we record the
-    // successful subset and warn on the rest. If zero land, we throw —
-    // the requester needs to know nobody got the message.
+    // Resolve users + post DMs in parallel. Per-reviewer the work is two
+    // sequential Slack calls (lookupByEmail → conversations.open +
+    // chat.postMessage), but the per-reviewer chains run concurrently so
+    // total wallclock latency is one round-trip pair rather than N. Each
+    // chain produces an Optional<ReviewerMessage>: empty when the user
+    // is not in the workspace, populated when DM landed. Failures end up
+    // as exceptionally-completed futures we sweep up with .handle().
     //
-    var posted = new ArrayList<ReviewerMessage>();
-    var failures = new ArrayList<String>();
+    //
+    // Per-reviewer outcome enum so the post-loop can distinguish three
+    // failure modes that the upstream lump-everything error didn't:
+    //   POSTED        — DM landed
+    //   NOT_IN_SLACK  — users.lookupByEmail returned null (not an
+    //                   error; the email simply isn't a Slack workspace
+    //                   member). Common for external-collaborator
+    //                   policies; not worth alarming on.
+    //   API_FAILURE   — an exception bubbled out of either Slack call.
+    //                   Typical: invalid token, missing scope, 5xx.
+    //                   Worth alerting on.
+    // Tracking these separately means the "all failed" error message
+    // tells the operator whether to fix Slack config or fix the policy.
+    //
+    var perReviewerFutures = fp.reviewerEmails().stream()
+      .map(email -> this.slackClient.lookupUserByEmail(email)
+        .thenCompose(userId -> {
+          if (userId == null) {
+            this.logger.warn(
+              "slack.lookupByEmail.notFound",
+              "Reviewer %s is not in the Slack workspace; skipping",
+              email);
+            return java.util.concurrent.CompletableFuture.completedFuture(
+              new DmOutcome(email, null, ReviewerOutcome.NOT_IN_SLACK));
+          }
+          return this.slackClient.postDirectMessage(userId, blocks, fallback)
+            .thenApply(msg -> new DmOutcome(
+              email,
+              new ReviewerMessage(email, userId, msg.channelId(), msg.messageTs()),
+              ReviewerOutcome.POSTED));
+        })
+        .handle((outcome, ex) -> {
+          if (ex != null) {
+            var cause = (ex.getCause() != null) ? ex.getCause() : ex;
+            this.logger.warn(
+              "slack.dm.failed",
+              "Failed to DM reviewer %s for %s: %s",
+              email, fp.groupId(), cause.getMessage());
+            return new DmOutcome(email, null, ReviewerOutcome.API_FAILURE);
+          }
+          return outcome;
+        }))
+      .toList();
 
-    for (var email : fp.reviewerEmails()) {
+    var posted = new ArrayList<ReviewerMessage>();
+    var notInSlack = new ArrayList<String>();
+    var apiFailures = new ArrayList<String>();
+    for (var future : perReviewerFutures) {
+      DmOutcome outcome;
       try {
-        String userId = this.slackClient.lookupUserByEmail(email).join();
-        if (userId == null) {
-          this.logger.warn(
-            "slack.lookupByEmail.notFound",
-            "Reviewer %s is not in the Slack workspace; skipping",
-            email);
-          failures.add(email);
-          continue;
-        }
-        SlackClient.PostedMessage message = this.slackClient
-          .postDirectMessage(userId, blocks, fallback)
-          .join();
-        posted.add(new ReviewerMessage(
-          email, userId, message.channelId(), message.messageTs()));
+        outcome = future.join();
       }
       catch (RuntimeException e) {
-        var cause = e.getCause() != null ? e.getCause() : e;
-        this.logger.warn(
-          "slack.dm.failed",
-          "Failed to DM reviewer %s for %s: %s",
-          email, fp.groupId(), cause.getMessage());
-        failures.add(email);
+        // .handle() above already converts failures to API_FAILURE
+        // outcomes, so this catch is defensive only.
+        outcome = null;
+      }
+      if (outcome == null || outcome.outcome() == ReviewerOutcome.API_FAILURE) {
+        apiFailures.add(outcome != null ? outcome.email() : "<unknown>");
+      } else if (outcome.outcome() == ReviewerOutcome.NOT_IN_SLACK) {
+        notInSlack.add(outcome.email());
+      } else {
+        posted.add(outcome.message());
       }
     }
 
     if (posted.isEmpty()) {
+      if (apiFailures.isEmpty()) {
+        // All recipients are policy-defined emails that aren't in the
+        // Slack workspace — typically a misconfigured policy ACL
+        // rather than an outage. Surface a different code so it
+        // alerts on a different runbook.
+        this.logger.error(
+          "slack.allReviewersNotInWorkspace",
+          "Every one of %d reviewer(s) on %s is unknown to the Slack "
+            + "workspace. Likely the policy ACL grants APPROVE_OTHERS to "
+            + "principals who aren't Slack users. emails=%s",
+          fp.reviewerEmails().size(), fp.groupId(), notInSlack);
+        throw new IOException(
+          "None of the " + fp.reviewerEmails().size()
+            + " qualified reviewers on " + fp.groupId()
+            + " are in the Slack workspace");
+      }
       this.logger.error(
         "slack.allDmsFailed",
         "Slack DM delivery failed for every one of %d reviewer(s) on %s. "
           + "See preceding slack.dm.failed entries for the per-reviewer "
-          + "cause (typical: missing Slack scope, invalid bot token, or "
-          + "user not in the workspace).",
-        fp.reviewerEmails().size(), fp.groupId());
+          + "cause (typical: missing Slack scope, invalid bot token, "
+          + "5xx). apiFailures=%d notInSlack=%d",
+        fp.reviewerEmails().size(), fp.groupId(),
+        apiFailures.size(), notInSlack.size());
       throw new IOException(
         "Slack DM delivery failed for every reviewer (" + fp.reviewerEmails().size()
           + ") on " + fp.groupId());
     }
+    var failures = new ArrayList<String>();
+    failures.addAll(notInSlack);
+    failures.addAll(apiFailures);
 
     try {
       this.registry.record(fp.key(), posted, token.expiryTime()).join();
@@ -264,6 +323,26 @@ public class SlackProposalHandler extends AbstractProposalHandler {
   ) throws AccessException, IOException {
     var fp = fingerprint(proposal);
     var approverEmail = operation.user().email;
+
+    //
+    // Wavemm fork: when the requester opted out of automated
+    // notification (notifyReviewers=false), no DMs were sent and no
+    // Firestore registry entry was ever written. There are no sibling
+    // DMs to update — only the beneficiary needs a confirmation that
+    // their request was approved. Skip the registry round-trip
+    // entirely; logging the absence as INFO instead of WARN avoids
+    // false-positive alerts on the operator side.
+    //
+    if (!proposal.notifyReviewers()) {
+      this.logger.info(
+        "slack.onProposalApproved.optOut",
+        "Approving request key=%s with notifyReviewers=false: no "
+          + "registry to update, only DMing the beneficiary. "
+          + "requester=%s group=%s approver=%s",
+        fp.key(), fp.beneficiary(), fp.groupId(), approverEmail);
+      notifyBeneficiary(fp.beneficiary(), fp.groupId(), approverEmail);
+      return;
+    }
 
     var entriesOpt = this.registry.lookup(fp.key()).join();
     if (entriesOpt.isEmpty()) {
@@ -356,4 +435,22 @@ public class SlackProposalHandler extends AbstractProposalHandler {
         "notificationTimeZone must not be null");
     }
   }
+
+  /**
+   * Per-reviewer outcome of the parallel DM fan-out in {@link
+   * #onOperationProposed}. Lets the post-loop distinguish "user isn't
+   * in Slack" from "Slack API broke" so the catastrophic
+   * "everybody-failed" error message can name the right culprit.
+   */
+  private enum ReviewerOutcome {
+    POSTED,
+    NOT_IN_SLACK,
+    API_FAILURE
+  }
+
+  private record DmOutcome(
+    @NotNull String email,
+    ReviewerMessage message,
+    @NotNull ReviewerOutcome outcome
+  ) {}
 }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/GroupsResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/GroupsResource.java
@@ -23,16 +23,22 @@ package com.google.solutions.jitaccess.web.rest;
 
 import com.google.solutions.jitaccess.apis.Logger;
 import com.google.solutions.jitaccess.apis.clients.AccessDeniedException;
+import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
+import com.google.solutions.jitaccess.auth.EndUserId;
+import com.google.solutions.jitaccess.auth.GroupResolver;
 import com.google.solutions.jitaccess.auth.JitGroupId;
 import com.google.solutions.jitaccess.auth.Principal;
+import com.google.solutions.jitaccess.auth.Subject;
 import com.google.solutions.jitaccess.catalog.Catalog;
 import com.google.solutions.jitaccess.catalog.JitGroupContext;
 import com.google.solutions.jitaccess.catalog.policy.PolicyAnalysis;
+import com.google.solutions.jitaccess.catalog.policy.PolicyPermission;
 import com.google.solutions.jitaccess.catalog.policy.Privilege;
 import com.google.solutions.jitaccess.catalog.policy.Property;
 import com.google.solutions.jitaccess.common.Coalesce;
 import com.google.solutions.jitaccess.web.*;
 import com.google.solutions.jitaccess.web.proposal.ProposalHandler;
+import com.google.solutions.jitaccess.web.proposal.ReviewerCandidates;
 import com.google.solutions.jitaccess.web.proposal.TokenObfuscator;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -44,11 +50,17 @@ import jakarta.ws.rs.core.UriInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Dependent
 @Path("/api")
@@ -79,6 +91,18 @@ public class GroupsResource {
   @Inject
   Consoles consoles;
 
+  @Inject
+  Options options;
+
+  @Inject
+  CloudIdentityGroupsClient groupsClient;
+
+  @Inject
+  Subject subject;
+
+  @Inject
+  Executor executor;
+
   /**
    * Get group details, including information about requirements
    * to join the group.
@@ -98,7 +122,7 @@ public class GroupsResource {
         .group(groupId)
         .map(grp -> GroupInfo.create(
           grp,
-          JoinInfo.forJoinAnalysis(grp)))
+          JoinInfo.forJoinAnalysis(grp, this.options.slackCopyLinkEnabled())))
         .orElseThrow(() -> NOT_FOUND);
     }
     catch (Exception e) {
@@ -106,6 +130,13 @@ public class GroupsResource {
       throw (Exception)e.fillInStackTrace();
     }
   }
+
+  // Form field names reserved for the picker UX. These are extracted
+  // from the request body before the rest is forwarded to the constraint
+  // inputs, so a constraint named `selectedReviewers` (improbable, but
+  // we reserve the namespace) wouldn't collide.
+  static final String FIELD_SELECTED_REVIEWERS = "selectedReviewers";
+  static final String FIELD_NOTIFY_REVIEWERS = "notifyReviewers";
 
   /**
    * Attempt to join the group.
@@ -129,6 +160,48 @@ public class GroupsResource {
         .orElseThrow(() -> NOT_FOUND);
 
       //
+      // Pop the picker UX form fields out of inputValues before the
+      // remaining constraint inputs are forwarded to the join op.
+      //
+      var selectedReviewers = parseSelectedReviewers(
+        inputValues.remove(FIELD_SELECTED_REVIEWERS));
+      var notifyReviewers = parseNotifyReviewers(
+        inputValues.remove(FIELD_NOTIFY_REVIEWERS));
+
+      //
+      // When the requester picked specific reviewers, validate every
+      // email is in the expanded qualified-peer set BEFORE calling
+      // propose. JoinOperation.propose trusts the filter is already
+      // an authorised subset (it short-circuits the recipients list
+      // to whatever we pass), so the security check needs to happen
+      // here where we have a GroupResolver to expand groups.
+      //
+      if (selectedReviewers != null && !selectedReviewers.isEmpty()) {
+        var qualified = group.policy().effectiveAccessControlList()
+          .allowedPrincipals(PolicyPermission.APPROVE_OTHERS.toMask())
+          .stream()
+          .filter(p -> !p.equals(this.subject.user()))
+          .filter(p -> p instanceof com.google.solutions.jitaccess.auth.IamPrincipalId)
+          .map(p -> (com.google.solutions.jitaccess.auth.IamPrincipalId) p)
+          .collect(Collectors.toCollection(HashSet::new));
+        var resolver = new GroupResolver(this.groupsClient, this.executor);
+        var allowedEmails = new ReviewerCandidates(resolver, this.groupsClient, this.executor)
+          .compute(this.subject.user(), qualified)
+          .stream()
+          .map(c -> c.email().toLowerCase())
+          .collect(Collectors.toSet());
+        var rejected = selectedReviewers.stream()
+          .map(EndUserId::value)
+          .filter(e -> !allowedEmails.contains(e.toLowerCase()))
+          .toList();
+        if (!rejected.isEmpty()) {
+          throw new AccessDeniedException(
+            "Selected reviewers are not authorised to approve this request: "
+              + String.join(", ", rejected));
+        }
+      }
+
+      //
       // Attempt to join.
       //
       var joinOp = group.join();
@@ -146,21 +219,38 @@ public class GroupsResource {
         //     the frontend then translates this into making the right
         //     API call.
         //
+        Function<String, URI> buildActionUri = token -> this.linkBuilder
+          .absoluteUriBuilder(this.uriInfo)
+          .path("/")
+          .queryParam("f", String.format(
+            "/environments/%s/proposal/%s",
+            environment, TokenObfuscator.encode(token)))
+          .build();
+
         var proposal = this.proposalHandler.propose(
           joinOp,
-          token -> this.linkBuilder
-            .absoluteUriBuilder(this.uriInfo)
-            .path("/")
-            .queryParam("f", String.format(
-              "/environments/%s/proposal/%s",
-              environment, TokenObfuscator.encode(token)))
-            .build());
+          buildActionUri,
+          new ProposalHandler.ProposeOptions(
+            selectedReviewers,
+            notifyReviewers));
 
         this.auditTrail.joinProposed(joinOp, proposal);
 
+        // Surface the approval URL to the requester only when copy-link
+        // mode is enabled — it lets them paste it manually elsewhere.
+        // When the mode is off the URL is still computed (via
+        // buildActionUri) but never returned, matching the upstream
+        // contract where the URL is only seen by reviewers.
+        var approvalUrl = this.options.slackCopyLinkEnabled()
+          ? buildActionUri.apply(proposal.value()).toString()
+          : null;
+
         return GroupInfo.create(
           group,
-          JoinInfo.forProposal(joinOp.input()));
+          JoinInfo.forProposal(
+            joinOp.input(),
+            approvalUrl,
+            this.options.slackCopyLinkEnabled()));
       }
       else {
         //
@@ -181,6 +271,116 @@ public class GroupsResource {
     catch (Exception e) {
       this.logger.warn(EventIds.API_JOIN_GROUP, e);
       throw (Exception)e.fillInStackTrace();
+    }
+  }
+
+  /**
+   * Cap on the number of selected reviewers a single picker submission
+   * can carry. Sane upper bound — ACLs that grant APPROVE_OTHERS to
+   * groups larger than this number still pass through the legacy "DM
+   * everyone" path because the picker can't fit them all on screen
+   * anyway.
+   */
+  static final int SELECTED_REVIEWERS_MAX = 50;
+
+  /**
+   * Parse the {@code selectedReviewers} multi-value form field into a
+   * {@code Set<EndUserId>}. Empty/missing → null (no filter, default
+   * behaviour). Bounded at {@link #SELECTED_REVIEWERS_MAX} to keep a
+   * hostile client from forcing arbitrary memory and Cloud Identity
+   * lookups; values without an {@code @} are rejected so we don't end
+   * up constructing meaningless {@code EndUserId}s.
+   */
+  private static @Nullable Set<EndUserId> parseSelectedReviewers(
+    @Nullable List<String> raw
+  ) {
+    if (raw == null || raw.isEmpty()) {
+      return null;
+    }
+    if (raw.size() > SELECTED_REVIEWERS_MAX) {
+      throw new BadRequestException(
+        "Too many reviewer selections (got " + raw.size()
+          + ", max " + SELECTED_REVIEWERS_MAX + ")");
+    }
+    var parsed = raw.stream()
+      .filter(s -> s != null && !s.isBlank())
+      .map(String::trim)
+      .filter(s -> s.contains("@"))
+      .map(EndUserId::new)
+      .collect(Collectors.toSet());
+    return parsed.isEmpty() ? null : parsed;
+  }
+
+  private static boolean parseNotifyReviewers(@Nullable List<String> raw) {
+    if (raw == null || raw.isEmpty()) {
+      return true;
+    }
+    // Last value wins (browsers may submit duplicates from a checkbox).
+    return Boolean.parseBoolean(raw.get(raw.size() - 1));
+  }
+
+  /**
+   * List candidate reviewers for the picker UX (wavemm fork). Returns
+   * the qualified peers from the policy ACL (after group expansion),
+   * with a {@code suggested} flag for those who share an approver group
+   * with the requester — i.e. likely-teammates.
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("environments/{environment}/systems/{system}/groups/{name}/reviewers")
+  public @NotNull ReviewersInfo getReviewers(
+    @PathParam("environment") @NotNull String environment,
+    @PathParam("system") @NotNull String system,
+    @PathParam("name") @NotNull String name
+  ) throws Exception {
+    try {
+      var groupId = new JitGroupId(environment, system, name);
+      var group = this.catalog
+        .group(groupId)
+        .orElseThrow(() -> NOT_FOUND);
+
+      // Compute the qualified peers the same way JoinOperation.propose
+      // does — union of principals with APPROVE_OTHERS, minus the
+      // requester (filtered at principal level here; ReviewerCandidates
+      // also filters at email level after group expansion).
+      var requester = this.subject.user();
+      var qualified = group.policy().effectiveAccessControlList()
+        .allowedPrincipals(PolicyPermission.APPROVE_OTHERS.toMask())
+        .stream()
+        .filter(p -> !p.equals(requester))
+        .filter(p -> p instanceof com.google.solutions.jitaccess.auth.IamPrincipalId)
+        .map(p -> (com.google.solutions.jitaccess.auth.IamPrincipalId) p)
+        .collect(Collectors.toCollection(HashSet::new));
+
+      var resolver = new GroupResolver(this.groupsClient, this.executor);
+      var helper = new ReviewerCandidates(resolver, this.groupsClient, this.executor);
+
+      List<ReviewerCandidates.Candidate> candidates;
+      try {
+        candidates = helper.compute(requester, qualified);
+      }
+      catch (com.google.solutions.jitaccess.apis.clients.AccessException
+        | java.io.IOException e) {
+        // Picker is best-effort: a Cloud Identity outage or a missing
+        // group-membership permission must not block the elevation
+        // request. Return the degraded shape and let the frontend
+        // render an explicit notice.
+        this.logger.warn(
+          EventIds.API_VIEW_GROUPS,
+          "Reviewer suggestions degraded for %s on %s: %s",
+          requester.email, groupId, e);
+        return new ReviewersInfo(List.of(), true);
+      }
+
+      return new ReviewersInfo(
+        candidates.stream()
+          .map(c -> new CandidateInfo(c.email(), c.displayName(), c.suggested()))
+          .toList(),
+        false);
+    }
+    catch (Exception e) {
+      this.logger.warn(EventIds.API_VIEW_GROUPS, e);
+      throw (Exception) e.fillInStackTrace();
     }
   }
 
@@ -300,10 +500,19 @@ public class GroupsResource {
     @NotNull MembershipInfo membership,
     @NotNull List<ConstraintInfo> satisfiedConstraints,
     @NotNull List<ConstraintInfo> unsatisfiedConstraints,
-    @NotNull List<InputInfo> input
+    @NotNull List<InputInfo> input,
+    /** JWT-bearing approval URL — non-null only when status is
+     *  JOIN_PROPOSED and SLACK_COPY_LINK_ENABLED is on, so the requester
+     *  can copy/share it manually. */
+    @Nullable String approvalUrl,
+    /** Mirrors the SLACK_COPY_LINK_ENABLED env flag. The picker UI uses
+     *  this to decide whether to render the "Notify reviewers in Slack"
+     *  checkbox and the copy-approval-link affordance. */
+    boolean copyLinkEnabled
   ) {
     static @NotNull GroupsResource.JoinInfo forJoinAnalysis(
-      @NotNull JitGroupContext g
+      @NotNull JitGroupContext g,
+      boolean copyLinkEnabled
     ) {
       var joinOp = g.join();
       var analysis = joinOp.dryRun();
@@ -338,7 +547,9 @@ public class GroupsResource {
         analysis.input().stream()
           .sorted(Comparator.comparing(p -> p.name()))
           .map(InputInfo::fromProperty)
-          .toList());
+          .toList(),
+        null,
+        copyLinkEnabled);
     }
 
     static @NotNull GroupsResource.JoinInfo forCompletedJoin(
@@ -358,11 +569,21 @@ public class GroupsResource {
           .stream()
           .sorted(Comparator.comparing(p -> p.name()))
           .map(InputInfo::fromProperty)
-          .toList());
+          .toList(),
+        null,
+        false);
     }
 
     static @NotNull GroupsResource.JoinInfo forProposal(
       @NotNull List<Property> input
+    ) {
+      return forProposal(input, null, false);
+    }
+
+    static @NotNull GroupsResource.JoinInfo forProposal(
+      @NotNull List<Property> input,
+      @Nullable String approvalUrl,
+      boolean copyLinkEnabled
     ) {
       return new JoinInfo(
         JoinStatusInfo.JOIN_PROPOSED,
@@ -373,9 +594,51 @@ public class GroupsResource {
           .stream()
           .sorted(Comparator.comparing(p -> p.name()))
           .map(InputInfo::fromProperty)
-          .toList());
+          .toList(),
+        approvalUrl,
+        copyLinkEnabled);
     }
   }
+
+  /**
+   * Configuration for this resource. Produced as a CDI singleton in
+   * {@code Application.java} from the corresponding
+   * {@link ApplicationConfiguration} fields.
+   */
+  public record Options(
+    boolean slackCopyLinkEnabled
+  ) {}
+
+  /**
+   * Response payload of {@code GET /reviewers}.
+   *
+   * <p>{@code degraded} means the candidates list is unavailable (Cloud
+   * Identity Groups API was down or the JIT SA was missing a
+   * permission on a group). The frontend uses this to render an
+   * explicit "Reviewer suggestions unavailable" notice instead of
+   * silently submitting with an empty selection.
+   *
+   * <p>The 200 + {@code degraded: true} contract is preferred over a
+   * 500 because the picker is best-effort: a failed peer lookup must
+   * not block the elevation request itself.
+   *
+   * <p>Not a {@link MediaInfo} — it's a sub-resource of the group, the
+   * frontend requests it explicitly and doesn't dispatch on {@code _type}.
+   */
+  public record ReviewersInfo(
+    @NotNull List<CandidateInfo> candidates,
+    boolean degraded
+  ) {}
+
+  /**
+   * One picker candidate. {@code suggested} marks teammates the
+   * requester shares an approver group with — the UI highlights these.
+   */
+  public record CandidateInfo(
+    @NotNull String email,
+    @NotNull String displayName,
+    boolean suggested
+  ) {}
 
   public record ExternalLinkInfo(
     @NotNull Link self,

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/GroupsResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/GroupsResource.java
@@ -21,6 +21,9 @@
 
 package com.google.solutions.jitaccess.web.rest;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.solutions.jitaccess.apis.Logger;
 import com.google.solutions.jitaccess.apis.clients.AccessDeniedException;
 import com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient;
@@ -234,7 +237,13 @@ public class GroupsResource {
             selectedReviewers,
             notifyReviewers));
 
-        this.auditTrail.joinProposed(joinOp, proposal);
+        // Plumb the notifyReviewers flag into the audit event so the
+        // log-based BigQuery dashboard distinguishes copy-link
+        // ("notifyReviewers=false") from the regular DM-everyone flow.
+        // Both still fall under api.groups.join — same event id —
+        // because they're the same domain action; the new label is
+        // what splits them.
+        this.auditTrail.joinProposed(joinOp, proposal, notifyReviewers);
 
         // Surface the approval URL to the requester only when copy-link
         // mode is enabled — it lets them paste it manually elsewhere.
@@ -284,12 +293,47 @@ public class GroupsResource {
   static final int SELECTED_REVIEWERS_MAX = 50;
 
   /**
+   * Strict shape validator for picker-submitted reviewer emails.
+   *
+   * <p>Wavemm fork P2-9: {@link EndUserId#parse}'s canonical regex
+   * {@code ^user:(.+)@(.+)$} is too permissive — it accepts
+   * {@code "@@@@"} (greedy {@code .+} eats {@code @}), strings with
+   * embedded whitespace, and multi-{@code @} forms. We need a tighter
+   * shape check at the REST boundary because anything that gets past
+   * here ends up in audit logs, Slack DM addressing, and the
+   * downstream subset-of-qualified-peers check (which is set-based
+   * and would silently drop the bogus value rather than alert).
+   *
+   * <p>Pattern rationale:
+   * <ul>
+   *   <li>local-part: one or more chars, none of which are {@code @}
+   *       or whitespace;
+   *   <li>exactly one {@code @};
+   *   <li>domain: at least one label, a dot, and a TLD label, with no
+   *       {@code @} or whitespace anywhere.
+   * </ul>
+   * That's deliberately stricter than RFC 5321 (we don't bother with
+   * IP-literal hosts, quoted local parts, etc.) — Wave's IdP only
+   * issues domain-shaped emails and the picker only ever submits
+   * those.
+   */
+  private static final java.util.regex.Pattern SELECTED_REVIEWER_EMAIL_PATTERN =
+    java.util.regex.Pattern.compile(
+      "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+
+  /**
    * Parse the {@code selectedReviewers} multi-value form field into a
    * {@code Set<EndUserId>}. Empty/missing → null (no filter, default
    * behaviour). Bounded at {@link #SELECTED_REVIEWERS_MAX} to keep a
    * hostile client from forcing arbitrary memory and Cloud Identity
-   * lookups; values without an {@code @} are rejected so we don't end
-   * up constructing meaningless {@code EndUserId}s.
+   * lookups.
+   *
+   * <p>Each value is shape-validated against {@link
+   * #SELECTED_REVIEWER_EMAIL_PATTERN} (wavemm fork P2-9) instead of
+   * the previous "contains @" check. Anything that doesn't match —
+   * empty local-part, multiple {@code @}, embedded whitespace, no TLD
+   * — gets rejected with a 400 so the client can fix the form rather
+   * than have it silently propagate as a malformed principal.
    */
   private static @Nullable Set<EndUserId> parseSelectedReviewers(
     @Nullable List<String> raw
@@ -302,12 +346,19 @@ public class GroupsResource {
         "Too many reviewer selections (got " + raw.size()
           + ", max " + SELECTED_REVIEWERS_MAX + ")");
     }
-    var parsed = raw.stream()
-      .filter(s -> s != null && !s.isBlank())
-      .map(String::trim)
-      .filter(s -> s.contains("@"))
-      .map(EndUserId::new)
-      .collect(Collectors.toSet());
+    var parsed = new java.util.HashSet<EndUserId>();
+    for (var value : raw) {
+      if (value == null || value.isBlank()) {
+        continue;
+      }
+      var trimmed = value.trim();
+      if (!SELECTED_REVIEWER_EMAIL_PATTERN.matcher(trimmed).matches()) {
+        throw new BadRequestException(
+          "selectedReviewers contains a value that is not a valid email: '"
+            + trimmed + "'");
+      }
+      parsed.add(new EndUserId(trimmed));
+    }
     return parsed.isEmpty() ? null : parsed;
   }
 
@@ -317,6 +368,52 @@ public class GroupsResource {
     }
     // Last value wins (browsers may submit duplicates from a checkbox).
     return Boolean.parseBoolean(raw.get(raw.size() - 1));
+  }
+
+  /**
+   * Per-user rate limit on {@link #getReviewers}. Each {@link
+   * ReviewerCandidates#compute} call is expensive — one
+   * {@code listMembershipsByUser} on the requester plus a parallel
+   * {@code listMemberships} fan-out across every group they belong to.
+   * Without a cap, a hostile (or buggy) frontend that polls the picker
+   * could trivially burn through the JIT App Engine SA's Cloud Identity
+   * quota and DoS legitimate elevation requests.
+   *
+   * <p>The bucket size and refill rate are chosen so a normal user
+   * filling out the picker (a few searches, maybe a refresh) sees no
+   * throttling, while a script polling at &gt;1 req/s gets 429s within
+   * a couple of seconds. Buckets evict after 5 min idle to bound
+   * memory in the face of many distinct callers.
+   */
+  static final double REVIEWERS_RATE_PER_SECOND = 1.0;
+  private static final Cache<String, RateLimiter> REVIEWERS_RATE_LIMITERS =
+    CacheBuilder.newBuilder()
+      .expireAfterAccess(Duration.ofMinutes(5))
+      .maximumSize(10_000)
+      .build();
+
+  // Package-private for tests; the cache lives in the same JVM, so
+  // tests that exercise it must reset state through clearReviewerLimiters().
+  static void clearReviewerRateLimiters() {
+    REVIEWERS_RATE_LIMITERS.invalidateAll();
+  }
+
+  static @NotNull RateLimiter rateLimiterFor(@NotNull String userKey) {
+    try {
+      // Guava's SmoothBursty RateLimiter accumulates up to one second of
+      // permits when idle — close enough to the burst pattern we want
+      // (one full picker open + a few quick edits). We don't try to
+      // hand-tune the burst here; the empirical floor for noisy clients
+      // is set by REVIEWERS_RATE_PER_SECOND once the burst is drained.
+      return REVIEWERS_RATE_LIMITERS.get(
+        userKey,
+        () -> RateLimiter.create(REVIEWERS_RATE_PER_SECOND));
+    }
+    catch (java.util.concurrent.ExecutionException e) {
+      // CacheLoader throwing is impossible here (lambda doesn't throw);
+      // defensive fallback uses a fresh limiter.
+      return RateLimiter.create(REVIEWERS_RATE_PER_SECOND);
+    }
   }
 
   /**
@@ -344,6 +441,20 @@ public class GroupsResource {
       // requester (filtered at principal level here; ReviewerCandidates
       // also filters at email level after group expansion).
       var requester = this.subject.user();
+
+      // Per-user rate limit. Failing to acquire surfaces as a 429 so a
+      // polling client backs off rather than silently DoSing the Cloud
+      // Identity quota. Authenticated principal email is the bucket
+      // key — IAP guarantees this is the actual end user, not a
+      // header-set value.
+      if (!rateLimiterFor(requester.email).tryAcquire()) {
+        this.logger.warn(
+          EventIds.API_VIEW_GROUPS,
+          "Reviewer-picker rate limit exceeded by %s on %s",
+          requester.email, groupId);
+        throw new WebApplicationException(
+          "Too many requests; please retry shortly.", 429);
+      }
       var qualified = group.policy().effectiveAccessControlList()
         .allowedPrincipals(PolicyPermission.APPROVE_OTHERS.toMask())
         .stream()

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/Inputs.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/Inputs.java
@@ -31,9 +31,25 @@ class Inputs {
   private Inputs() {}
 
   /**
+   * Absolute per-input length cap enforced at the REST boundary,
+   * independent of policy-defined {@code maxLength}.
+   *
+   * <p>Defense-in-depth: a misconfigured (or unbounded) string property
+   * in policy YAML must not let a hostile requester submit a multi-MB
+   * justification that downstream consumers — Slack Block Kit (3 KB
+   * field cap), Firestore documents, audit logs — would then have to
+   * carry, truncate, or reject. The cap is generous enough to never
+   * collide with a reasonable human-written justification (16 KB ≈
+   * several pages of dense prose) and well below the Quarkus request
+   * body limit (10 MB), so it's only triggered by abuse.
+   */
+  static final int INPUT_MAX_LENGTH = 16_384;
+
+  /**
    * Copy input values.
    *
-   * @throws IllegalArgumentException if the input values are incomplete.
+   * @throws IllegalArgumentException if the input values are incomplete
+   *         or any value exceeds {@link #INPUT_MAX_LENGTH}.
    */
   public static void copyValues(
     @NotNull MultivaluedMap<String, String> source,
@@ -41,7 +57,14 @@ class Inputs {
   ) {
     for (var input : target) {
       if (source.containsKey(input.name())) {
-        input.set(source.get(input.name()).get(0));
+        var value = source.get(input.name()).get(0);
+        if (value != null && value.length() > INPUT_MAX_LENGTH) {
+          throw new IllegalArgumentException(
+            String.format(
+              "'%s' is too long (got %d characters, max %d)",
+              input.displayName(), value.length(), INPUT_MAX_LENGTH));
+        }
+        input.set(value);
       }
       else if (input.isRequired()) {
         throw new IllegalArgumentException(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/SystemsResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/SystemsResource.java
@@ -56,6 +56,9 @@ public class SystemsResource {
   @Inject
   Logger logger;
 
+  @Inject
+  GroupsResource.Options groupsOptions;
+
   /**
    * Get system details, including the list of groups that
    * the current user is allowed to view.
@@ -68,10 +71,11 @@ public class SystemsResource {
     @PathParam("system") @NotNull String system
   ) throws Exception {
     try {
+      var copyLinkEnabled = this.groupsOptions.slackCopyLinkEnabled();
       return this.catalog
         .environment(environment)
         .flatMap(env -> env.system(system))
-        .map(sys -> SystemInfo.create(sys))
+        .map(sys -> SystemInfo.create(sys, copyLinkEnabled))
         .orElseThrow(() -> NOT_FOUND);
     }
     catch (Exception e) {
@@ -110,9 +114,16 @@ public class SystemsResource {
     }
 
     /**
-     * Create SystemInfo with full details.
+     * Create SystemInfo with full details. {@code copyLinkEnabled} is
+     * the deployment-wide flag that gates the picker's "Notify in Slack"
+     * toggle and the post-submit approval-link box; it's passed in by
+     * the resource method (where the injected GroupsResource.Options
+     * is reachable) because this factory is static.
      */
-    static SystemInfo create(@NotNull SystemContext system) {
+    static SystemInfo create(
+      @NotNull SystemContext system,
+      boolean copyLinkEnabled
+    ) {
       var policy = system.policy();
 
       return new SystemInfo(
@@ -126,7 +137,7 @@ public class SystemsResource {
           .sorted(Comparator.comparing(grp -> grp.policy().displayName()))
           .map(grp -> GroupsResource.GroupInfo.create(
             grp,
-            GroupsResource.JoinInfo.forJoinAnalysis(grp)))
+            GroupsResource.JoinInfo.forJoinAnalysis(grp, copyLinkEnabled)))
           .toList());
     }
   }

--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -673,13 +673,246 @@
                         groupInfo.join.input.forEach(item => {
                             this.select('form').append(this._createInputForProperty(item));
                         });
+                        // Wavemm fork: show the reviewer picker only when MPA is required.
+                        // The picker UI fetches qualified peers and lets the requester
+                        // narrow the recipient list; with copyLinkEnabled the requester
+                        // can also opt out of Slack delivery and copy the JWT URL manually.
+                        if (groupInfo.join.status === 'JOIN_ALLOWED_WITH_APPROVAL') {
+                            this._renderReviewerPickerAsync(groupInfo.join.copyLinkEnabled);
+                        }
                         break;
 
                     case 'JOIN_COMPLETED':
-                    case 'JOIN_PROPOSED':
                     case 'JOIN_DISALLOWED':
                         this.select('.jit-form').hide();
+                        break;
+
+                    case 'JOIN_PROPOSED':
+                        this.select('.jit-form').hide();
+                        // Wavemm fork: surface the approval URL so the requester
+                        // can copy/share it manually when they opted out of Slack
+                        // (or as a fallback if Slack delivery had an issue).
+                        if (groupInfo.join.approvalUrl) {
+                            this._renderApprovalUrl(groupInfo.join.approvalUrl);
+                        }
+                        break;
                 }
+            }
+
+            /**
+             * Wavemm fork: fetch /reviewers and append the picker UI to the
+             * join form. Renders one checkbox per qualified peer, with
+             * suggested teammates visually highlighted (badge) but NOT
+             * pre-checked — leaving every box empty preserves the upstream
+             * "no action = notify all qualified peers" semantic, and makes
+             * the picker an opt-in narrowing tool rather than a silent
+             * narrowing default. When copyLinkEnabled is true, also renders
+             * a "Notify reviewers in Slack" toggle wired as a hidden+checkbox
+             * pair so the form submits notifyReviewers=false when the box is
+             * unchecked.
+             */
+            async _renderReviewerPickerAsync(copyLinkEnabled) {
+                let response;
+                try {
+                    response = await document.appbar.model.listReviewers();
+                }
+                catch (e) {
+                    // Hard /reviewers failure (5xx, network). Picker is
+                    // best-effort: user can still submit without selection
+                    // and the backend defaults to notifying every qualified
+                    // peer. Log + render the degraded notice for clarity.
+                    console.warn("Failed to load reviewer candidates:", e);
+                    this._renderPickerDegradedNotice();
+                    return;
+                }
+                if (response && response.degraded) {
+                    // Backend returned 200 with degraded:true — Cloud
+                    // Identity Groups API was unavailable or missing perms.
+                    // Show the notice instead of an empty picker.
+                    this._renderPickerDegradedNotice();
+                    return;
+                }
+                const candidates = response ? response.candidates : null;
+                if (!candidates || candidates.length === 0) {
+                    return;
+                }
+
+                const form = this.select('form');
+                const picker = $(`
+                    <div class="jit-reviewer-picker">
+                        <div class="jit-reviewer-picker-label">
+                            Select reviewers
+                            <span class="jit-reviewer-picker-hint">
+                                — pick one or more teammates (those tagged
+                                <strong>team</strong> are likely on yours).
+                                Leave all unchecked to notify every qualified peer.
+                            </span>
+                        </div>
+                        <input type="search"
+                               class="jit-reviewer-picker-filter"
+                               placeholder="Filter reviewers…"
+                               aria-label="Filter reviewers"/>
+                        <ul class="jit-reviewer-picker-list"></ul>
+                    </div>
+                `);
+                const list = picker.find('.jit-reviewer-picker-list');
+
+                // Build each picker item as DOM nodes (jQuery .text() / .attr())
+                // rather than HTML template literals — every field below comes
+                // from a server response that ultimately derives from
+                // operator-controlled policy YAML (ACL principals), so we
+                // never want unescaped interpolation. Construct elements +
+                // set their text/attrs via jQuery so injected content is
+                // always treated as data.
+                candidates.forEach(c => {
+                    const sanitisedId = ('jit-reviewer-' + (c.email || ''))
+                        .replace(/[^a-zA-Z0-9_-]/g, '_');
+                    const li = $('<li>')
+                        .addClass('jit-reviewer-picker-item')
+                        .toggleClass('jit-reviewer-suggested', !!c.suggested)
+                        .attr('data-email', c.email || '')
+                        .attr('data-display', c.displayName || '');
+                    const label = $('<label>').attr('for', sanitisedId);
+                    const checkbox = $('<input>')
+                        .attr('type', 'checkbox')
+                        .attr('id', sanitisedId)
+                        .attr('name', 'selectedReviewers')
+                        .attr('value', c.email || '');
+                    // Default unchecked even for suggested. The picker is
+                    // an opt-in narrowing tool: an untouched form must
+                    // continue to mean "notify every qualified peer", same
+                    // as before the picker existed. The badge remains as
+                    // a visual hint of who likely makes a good reviewer.
+                    const display = $('<span>')
+                        .addClass('jit-reviewer-display')
+                        .text(c.displayName || c.email || '');
+                    label.append(checkbox).append(display);
+                    if (c.suggested) {
+                        label.append($('<span>')
+                            .addClass('jit-reviewer-badge')
+                            .text('team'));
+                    }
+                    li.append(label);
+                    list.append(li);
+                });
+
+                // Client-side filter: hide list items whose email/display
+                // doesn't contain the search text (case-insensitive).
+                picker.find('.jit-reviewer-picker-filter').on('input', (e) => {
+                    const q = $(e.target).val().toLowerCase();
+                    list.find('.jit-reviewer-picker-item').each((_, el) => {
+                        const $el = $(el);
+                        const hay = ($el.data('email') + ' ' + $el.data('display')).toLowerCase();
+                        $el.toggle(!q || hay.includes(q));
+                    });
+                });
+
+                // The "notify reviewers in Slack" toggle. Hidden+checkbox
+                // pattern: when unchecked, only the hidden submits "false";
+                // when checked, both submit and the parser takes the last
+                // value ("true") — see GroupsResource.parseNotifyReviewers.
+                if (copyLinkEnabled) {
+                    picker.append(`
+                        <div class="jit-notify-toggle">
+                            <input type="hidden" name="notifyReviewers" value="false"/>
+                            <label>
+                                <input type="checkbox"
+                                       name="notifyReviewers"
+                                       value="true"
+                                       checked/>
+                                Notify selected reviewers in Slack
+                                <span class="jit-reviewer-picker-hint">
+                                    — uncheck to receive a copy-able approval link
+                                    instead and share it manually.
+                                </span>
+                            </label>
+                        </div>
+                    `);
+                }
+
+                form.append(picker);
+            }
+
+            /**
+             * Wavemm fork: render an explicit notice when /reviewers came
+             * back degraded (Cloud Identity outage or missing perms) or
+             * threw outright. Without this, an empty picker is
+             * indistinguishable from "no qualified peers" — the user
+             * would submit and get DM'd-everyone behaviour without
+             * realising suggestion-narrowing wasn't actually offered.
+             */
+            _renderPickerDegradedNotice() {
+                const form = this.select('form');
+                const notice = $('<div>')
+                    .addClass('jit-reviewer-picker jit-reviewer-picker-degraded')
+                    .append($('<div>')
+                        .addClass('jit-reviewer-picker-label')
+                        .text('Reviewer suggestions unavailable'))
+                    .append($('<div>')
+                        .addClass('jit-reviewer-picker-hint')
+                        .text(
+                            'Couldn\'t load the list of qualified reviewers ' +
+                            '(Cloud Identity API hiccup). Submitting will fall ' +
+                            'back to notifying every qualified peer per the policy.'));
+                form.append(notice);
+            }
+
+            /**
+             * Wavemm fork: render the approval URL the user can copy and
+             * forward. Only fires when JOIN_PROPOSED comes back with
+             * approvalUrl set (i.e., copyLinkEnabled is true on the
+             * deployment).
+             */
+            _renderApprovalUrl(url) {
+                const view = this.select('.jit-form').parent();
+                view.find('.jit-approval-link-box').remove();
+                // The structural HTML is a literal — only the URL is
+                // server-derived, and we set it as a value attribute via
+                // jQuery .val() so the URL never enters the HTML parser
+                // (the input's `value` attribute is a string, not a JS
+                // expression context). Defence-in-depth: even if the URL
+                // were attacker-controlled, .val() prevents <script>-tag
+                // injection, while .text() inside the row label below
+                // ensures any future mistake doesn't escalate.
+                const box = $(`
+                    <div class="jit-card-subsection jit-approval-link-box">
+                        <div class="jit-approval-link-label">
+                            Approval link — share this with the reviewer of your choice:
+                        </div>
+                        <div class="jit-approval-link-row">
+                            <input type="text"
+                                   class="jit-approval-link-url"
+                                   readonly
+                                   aria-label="Approval link"/>
+                            <button type="button"
+                                    class="mdc-button mdc-button--outlined jit-approval-link-copy">
+                                <span class="mdc-button__ripple"></span>
+                                <span class="mdc-button__label">Copy</span>
+                            </button>
+                        </div>
+                        <div class="jit-reviewer-picker-hint">
+                            The link is signed and only valid for the reviewers
+                            you selected when submitting. It expires when the
+                            request times out.
+                        </div>
+                    </div>
+                `);
+                box.find('.jit-approval-link-url').val(url);
+                box.find('.jit-approval-link-copy').on('click', async () => {
+                    try {
+                        await navigator.clipboard.writeText(url);
+                        box.find('.jit-approval-link-copy .mdc-button__label').text('Copied!');
+                        setTimeout(() => {
+                            box.find('.jit-approval-link-copy .mdc-button__label').text('Copy');
+                        }, 1500);
+                    }
+                    catch (e) {
+                        // Fallback for environments without Clipboard API access:
+                        // select the text so the user can Cmd/Ctrl-C manually.
+                        box.find('.jit-approval-link-url').get(0).select();
+                    }
+                });
+                view.append(box);
             }
 
             _bindGroupMembership(groupInfo) {

--- a/sources/src/main/resources/META-INF/resources/model.js
+++ b/sources/src/main/resources/META-INF/resources/model.js
@@ -120,6 +120,24 @@ class Model {
             throw ModelError.fromAjaxError(error);
         }
     }
+
+    /**
+     * Wavemm fork: fetch the candidate-reviewers list for the picker UX.
+     * The endpoint sits at `${groupResource}/reviewers` and returns
+     * { candidates: [{ email, displayName, suggested }] }.
+     */
+    async listReviewers() {
+        try {
+            return await $.ajax({
+                url: `/api${this.resource}/reviewers`,
+                dataType: "json",
+                headers: this._getHeaders()
+            });
+        }
+        catch (error) {
+            throw ModelError.fromAjaxError(error);
+        }
+    }
 }
 
 class DebugModel extends Model {

--- a/sources/src/main/resources/META-INF/resources/styles.css
+++ b/sources/src/main/resources/META-INF/resources/styles.css
@@ -352,3 +352,147 @@ main .mdc-button {
 .jit-system-description {
   white-space: pre-line;   /* pre-wrap also works */
 }
+
+/* ==== Wavemm fork: reviewer picker + copy-link UI ==== */
+
+.jit-reviewer-picker {
+    margin-top: 16px;
+    padding: 12px 0;
+    border-top: 1px solid #e0e0e0;
+}
+
+.jit-reviewer-picker-degraded {
+    background: #fff8e1;
+    border: 1px solid #f0c674;
+    border-top: 1px solid #f0c674;
+    border-radius: 4px;
+    padding: 12px;
+    margin-top: 16px;
+}
+
+.jit-reviewer-picker-degraded .jit-reviewer-picker-label {
+    color: #8b6914;
+}
+
+.jit-reviewer-picker-label {
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #000000a8;
+}
+
+.jit-reviewer-picker-hint {
+    font-weight: normal;
+    color: #00000080;
+    font-size: 11px;
+    margin-left: 4px;
+}
+
+.jit-reviewer-picker-filter {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    font-size: 13px;
+    margin-bottom: 8px;
+    box-sizing: border-box;
+}
+
+.jit-reviewer-picker-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid #f0f0f0;
+    border-radius: 4px;
+}
+
+.jit-reviewer-picker-item {
+    padding: 4px 8px;
+    border-bottom: 1px solid #f5f5f5;
+}
+
+.jit-reviewer-picker-item:last-child {
+    border-bottom: none;
+}
+
+.jit-reviewer-picker-item label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 4px 0;
+}
+
+.jit-reviewer-picker-item input[type="checkbox"] {
+    margin-right: 10px;
+}
+
+.jit-reviewer-picker-item.jit-reviewer-suggested {
+    background: #f0f7ff;
+}
+
+.jit-reviewer-display {
+    flex: 1;
+}
+
+.jit-reviewer-badge {
+    display: inline-block;
+    background: #1a73e8;
+    color: white;
+    font-size: 10px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 10px;
+    margin-left: 8px;
+    text-transform: uppercase;
+}
+
+.jit-notify-toggle {
+    margin-top: 12px;
+    padding: 10px;
+    background: #fafafa;
+    border-radius: 4px;
+}
+
+.jit-notify-toggle label {
+    display: flex;
+    align-items: flex-start;
+    cursor: pointer;
+}
+
+.jit-notify-toggle input[type="checkbox"] {
+    margin-right: 10px;
+    margin-top: 2px;
+}
+
+/* Approval-link box rendered after JOIN_PROPOSED when approvalUrl is set */
+.jit-approval-link-box {
+    margin-top: 16px;
+    padding: 16px;
+    background: #f8f9fa;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.jit-approval-link-label {
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #000000a8;
+}
+
+.jit-approval-link-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+    margin-bottom: 6px;
+}
+
+.jit-approval-link-url {
+    flex: 1;
+    padding: 6px 10px;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    font-family: Consolas, monospace;
+    font-size: 11px;
+    background: white;
+}

--- a/sources/src/main/resources/application.properties
+++ b/sources/src/main/resources/application.properties
@@ -33,3 +33,13 @@ quarkus.http.filter.other.order=1
 
 # Ignore null fields when serializing responses to JSON
 quarkus.jackson.serialization-inclusion=non-null
+
+# Wavemm fork P2-13: cap the Slack SDK's logger at INFO so its DEBUG
+# traces — which include the bot token in HTTP request lines and full
+# response bodies — never reach Cloud Logging. Slack's
+# slack-api-client emits DEBUG-level logs of every request/response
+# pair when the root logger is DEBUG; even though our root level is
+# INFO, this is a defense-in-depth pin so a future operator who flips
+# everything to DEBUG to investigate an issue doesn't accidentally
+# leak a Bearer xoxb-… token into the audit pipeline.
+quarkus.log.category."com.slack.api".level=INFO

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
@@ -674,6 +674,93 @@ public class TestJitGroupContext {
       "Null filter must reproduce the upstream behaviour exactly");
   }
 
+  /**
+   * Wavemm fork P1-6 (catalog owns the invariant): when the policy ACL
+   * has only direct EndUserId approvers, the catalog can fully verify
+   * the filter locally — and must reject any entry that isn't in the
+   * direct ACL. This catches a future caller that forgets the
+   * REST-layer subset-after-expansion check (defense in depth).
+   */
+  @Test
+  public void join_propose_withFilterContainingNonAclUser_andNoGroupApprover_throws() {
+    var subject = Subjects.create(SAMPLE_USER);
+    var groupPolicy = new JitGroupPolicy(
+      "group-1",
+      "Group 1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(),
+      List.of(),
+      false);
+
+    createEnvironmentPolicy()
+      .add(new SystemPolicy("system-1", "System")
+        .add(groupPolicy));
+
+    var join = new JitGroupContext(
+      groupPolicy,
+      subject,
+      Mockito.mock(Provisioner.class))
+      .join();
+
+    var expiry = Instant.now().plusSeconds(60);
+    var hostileFilter = Set.of(
+      SAMPLE_APPROVER_1,                 // legitimate
+      new EndUserId("attacker@evil"));   // not in ACL
+
+    var ex = assertThrows(
+      AccessDeniedException.class,
+      () -> join.propose(expiry, hostileFilter));
+    assertTrue(ex.getMessage().contains("attacker@evil"),
+      "Catalog must name the rejected principal so the operator can "
+        + "trace which caller forgot the REST-layer expansion check; got: "
+        + ex.getMessage());
+  }
+
+  /**
+   * Wavemm fork P1-6: when the ACL contains a {@link GroupId} approver,
+   * the catalog cannot prove a filter entry isn't a member of that
+   * group without going to Cloud Identity. It therefore trusts the
+   * REST layer's expansion-aware check and lets the filter through.
+   * This preserves the typical "team approves team" pattern.
+   */
+  @Test
+  public void join_propose_withFilterAndAclHasGroupApprover_trustsRestLayer()
+    throws Exception {
+    var subject = Subjects.create(SAMPLE_USER);
+    var groupPolicy = new JitGroupPolicy(
+      "group-1",
+      "Group 1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .allow(SAMPLE_APPROVER_GROUP, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(),
+      List.of(),
+      false);
+
+    createEnvironmentPolicy()
+      .add(new SystemPolicy("system-1", "System")
+        .add(groupPolicy));
+
+    var join = new JitGroupContext(
+      groupPolicy,
+      subject,
+      Mockito.mock(Provisioner.class))
+      .join();
+
+    // SAMPLE_APPROVER_1 isn't in the ACL directly, but the ACL has a
+    // group approver — we trust the REST layer to have confirmed
+    // SAMPLE_APPROVER_1 ∈ expand(SAMPLE_APPROVER_GROUP).
+    var expiry = Instant.now().plusSeconds(60);
+    var proposal = join.propose(expiry, Set.of(SAMPLE_APPROVER_1));
+
+    assertEquals(Set.of(SAMPLE_APPROVER_1), proposal.recipients(),
+      "Filter through with group ACL must produce the filtered set");
+  }
+
   // -------------------------------------------------------------------------
   // approve.
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/catalog/TestJitGroupContext.java
@@ -593,6 +593,87 @@ public class TestJitGroupContext {
     assertEquals("123", proposal.input().get("long"));
   }
 
+  /**
+   * Wavemm fork P0-1 regression: when the requester picks a single
+   * approver via the picker, {@code propose(expiry, filter)} must
+   * substitute recipients with that user only — even when the policy
+   * ACL is groups-only after expansion. The previous implementation
+   * passed groups through unconditionally, defeating the picker.
+   */
+  @Test
+  public void join_propose_withReviewerFilter_substitutesRecipients() throws Exception {
+    var subject = Subjects.create(SAMPLE_USER);
+    var groupPolicy = new JitGroupPolicy(
+      "group-1",
+      "Group 1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
+        .allow(SAMPLE_APPROVER_2, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(),
+      List.of(),
+      false);
+
+    createEnvironmentPolicy()
+      .add(new SystemPolicy("system-1", "System")
+        .add(groupPolicy));
+
+    var join = new JitGroupContext(
+      groupPolicy,
+      subject,
+      Mockito.mock(Provisioner.class))
+      .join();
+
+    var expiry = Instant.now().plusSeconds(60);
+    var filtered = join.propose(expiry, Set.of(SAMPLE_APPROVER_1));
+
+    assertEquals(
+      Set.of(SAMPLE_APPROVER_1),
+      filtered.recipients(),
+      "Filter must replace the policy-derived approvers, not union with them");
+  }
+
+  /**
+   * Wavemm fork: a null/empty filter falls back to the upstream
+   * "every qualified peer" set, identical to the no-arg overload.
+   * (Validates that the filter overload doesn't accidentally narrow
+   * to nothing when the picker submits with no selection.)
+   */
+  @Test
+  public void join_propose_withNullFilter_keepsPolicyDerivedApprovers() throws Exception {
+    var subject = Subjects.create(SAMPLE_USER);
+    var groupPolicy = new JitGroupPolicy(
+      "group-1",
+      "Group 1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .allow(SAMPLE_APPROVER_1, PolicyPermission.APPROVE_OTHERS.toMask())
+        .allow(SAMPLE_APPROVER_2, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(),
+      List.of(),
+      false);
+
+    createEnvironmentPolicy()
+      .add(new SystemPolicy("system-1", "System")
+        .add(groupPolicy));
+
+    var join = new JitGroupContext(
+      groupPolicy,
+      subject,
+      Mockito.mock(Provisioner.class))
+      .join();
+
+    var expiry = Instant.now().plusSeconds(60);
+    var withNull = join.propose(expiry, null);
+
+    assertEquals(
+      Set.of(SAMPLE_APPROVER_1, SAMPLE_APPROVER_2),
+      withNull.recipients(),
+      "Null filter must reproduce the upstream behaviour exactly");
+  }
+
   // -------------------------------------------------------------------------
   // approve.
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/TestOperationAuditTrail.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/TestOperationAuditTrail.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class TestOperationAuditTrail {
@@ -156,6 +157,56 @@ public class TestOperationAuditTrail {
       "User 'user:user-1@example.com' asked to join group 'jit-group:env-1.system-1.group-1', " +
         "proposed to 'user:user-2@example.com', 'user:user-3@example.com' for approval",
       entry.message);
+    // Single-arg overload defaults to notifyReviewers=true, matching upstream.
+    assertEquals(
+      "true",
+      entry.labels.get(OperationAuditTrail.LABEL_PROPOSAL_NOTIFY_REVIEWERS));
+  }
+
+  /**
+   * Wavemm fork P1-8/P2-10: when the requester opted out of automated
+   * notification (copy-link path), the audit event must carry the
+   * distinct {@code proposal/notify_reviewers=false} label and a
+   * message body that names the copy-link mode. This is what lets a
+   * security analyst slice "approval requests not visible to the
+   * normal reviewer set" in the BigQuery sink.
+   */
+  @Test
+  public void joinProposed_whenNotifyReviewersFalse_emitsDistinctLabelAndMessage() {
+    var entry = new LogEntry();
+    var logger = Mockito.mock(Logger.class);
+    when(logger.buildInfo(EventIds.API_JOIN_GROUP))
+      .thenReturn(entry);
+
+    var joinOp = Mockito.mock(JitGroupContext.JoinOperation.class);
+    when(joinOp.user()).thenReturn(SAMPLER_USER_1);
+    when(joinOp.group()).thenReturn(SAMPLE_JITGROUP);
+    when(joinOp.input()).thenReturn(List.of());
+
+    var trail = new OperationAuditTrail(logger);
+    trail.joinProposed(
+      joinOp,
+      new ProposalHandler.ProposalToken(
+        "token",
+        Set.of(SAMPLER_USER_2, SAMPLER_USER_3),
+        Instant.now()),
+      false);
+
+    assertEquals(
+      "false",
+      entry.labels.get(OperationAuditTrail.LABEL_PROPOSAL_NOTIFY_REVIEWERS),
+      "copy-link path must surface notifyReviewers=false on the label");
+    assertTrue(entry.message.contains("copy-link"),
+      "message body must name the copy-link mode so log greps can spot "
+        + "out-of-band approvals; got: " + entry.message);
+    assertTrue(entry.message.contains("NOT auto-notified"),
+      "message body must make explicit that reviewers were authorised "
+        + "but not pinged; got: " + entry.message);
+    // Recipients label must still be populated — the qualified set is
+    // what got authorised, even though they weren't auto-notified.
+    assertEquals(
+      "user:user-2@example.com,user:user-3@example.com",
+      entry.labels.get(OperationAuditTrail.LABEL_PROPOSAL_RECIPIENTS));
   }
 
   //---------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestAbstractProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestAbstractProposalHandler.java
@@ -127,7 +127,7 @@ public class TestAbstractProposalHandler {
       .thenReturn(SAMPLE_USER_1);
     when(operation.group())
       .thenReturn(SAMPLE_JITGROUP_ID);
-    when(operation.propose(any()))
+    when(operation.propose(any(), any()))
       .thenReturn(proposal);
 
     var signer = new PseudoSigner();
@@ -158,7 +158,7 @@ public class TestAbstractProposalHandler {
       .thenReturn(SAMPLE_USER_1);
     when(operation.group())
       .thenReturn(SAMPLE_JITGROUP_ID);
-    when(operation.propose(any()))
+    when(operation.propose(any(), any()))
       .thenReturn(proposal);
 
     var signer = new PseudoSigner();
@@ -225,5 +225,45 @@ public class TestAbstractProposalHandler {
     assertFalse(proposal.input().isEmpty());
     assertEquals(1, proposal.input().size());
     assertEquals("value1", proposal.input().get("prop1"));
+  }
+
+  /**
+   * Wavemm fork P1-2: a token without the `ntf` claim (legacy or
+   * propose-time default) decodes with {@code notifyReviewers() = true},
+   * matching upstream behaviour.
+   */
+  @Test
+  public void accept_whenNotifyClaimAbsent_defaultsToTrue() throws Exception {
+    var token = "{\"rcp\":[\"user:user-2@example.com\"]," +
+      "\"grp\":\"jit-group:env.sys.group-1\"," +
+      "\"usr\":\"user:user-1@example.com\",\"inp\":{}}";
+
+    var signer = new PseudoSigner();
+    var proposalHandler = new SampleProposalHandler(signer);
+    var proposal = proposalHandler.accept(token);
+
+    assertTrue(proposal.notifyReviewers(),
+      "Absent ntf claim must decode as the upstream default (true)");
+  }
+
+  /**
+   * Wavemm fork P1-2 round-trip: a token with `ntf=false` set at
+   * propose-time round-trips through accept and surfaces as
+   * {@code proposal.notifyReviewers() == false}, allowing downstream
+   * handlers (SlackProposalHandler) to short-circuit cleanly.
+   */
+  @Test
+  public void accept_whenNotifyClaimFalse_propagates() throws Exception {
+    var token = "{\"rcp\":[\"user:user-2@example.com\"]," +
+      "\"grp\":\"jit-group:env.sys.group-1\"," +
+      "\"usr\":\"user:user-1@example.com\",\"inp\":{},\"ntf\":false}";
+
+    var signer = new PseudoSigner();
+    var proposalHandler = new SampleProposalHandler(signer);
+    var proposal = proposalHandler.accept(token);
+
+    assertFalse(proposal.notifyReviewers(),
+      "ntf=false claim must decode so the Slack handler short-circuits "
+        + "the registry-lookup branch on opt-out approvals");
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessageRegistry.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessageRegistry.java
@@ -10,13 +10,28 @@
 
 package com.google.solutions.jitaccess.web.proposal;
 
+import com.google.cloud.firestore.Firestore;
+import com.google.solutions.jitaccess.apis.Logger;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestSlackMessageRegistry {
+
+  private static final String SALT_A = "test-salt-A-must-be-at-least-32-bytes-long-xxx";
+  private static final String SALT_B = "test-salt-B-different-from-A-also-32-bytes-yyy";
+
+  private static SlackMessageRegistry newRegistry(String salt) {
+    return new SlackMessageRegistry(
+      Mockito.mock(Firestore.class),
+      Mockito.mock(Executor.class),
+      Mockito.mock(Logger.class),
+      salt);
+  }
 
   // -------------------------------------------------------------------------
   // requestKey — must be stable, deterministic, and order-independent on
@@ -26,25 +41,27 @@ public class TestSlackMessageRegistry {
 
   @Test
   public void requestKey_isDeterministic() {
-    var k1 = SlackMessageRegistry.requestKey(
+    var registry = newRegistry(SALT_A);
+    var k1 = registry.requestKey(
       "alice@example.com",
       "env/sys/grp",
       List.of("bob@example.com", "carol@example.com"));
-    var k2 = SlackMessageRegistry.requestKey(
+    var k2 = registry.requestKey(
       "alice@example.com",
       "env/sys/grp",
       List.of("bob@example.com", "carol@example.com"));
     assertEquals(k1, k2);
-    assertEquals(64, k1.length(), "SHA-256 hex");
+    assertEquals(64, k1.length(), "HMAC-SHA-256 hex");
   }
 
   @Test
   public void requestKey_isInvariantToRecipientOrder() {
-    var k1 = SlackMessageRegistry.requestKey(
+    var registry = newRegistry(SALT_A);
+    var k1 = registry.requestKey(
       "alice@example.com",
       "env/sys/grp",
       List.of("bob@example.com", "carol@example.com"));
-    var k2 = SlackMessageRegistry.requestKey(
+    var k2 = registry.requestKey(
       "alice@example.com",
       "env/sys/grp",
       List.of("carol@example.com", "bob@example.com"));
@@ -55,36 +72,70 @@ public class TestSlackMessageRegistry {
 
   @Test
   public void requestKey_distinguishesBeneficiary() {
-    var k1 = SlackMessageRegistry.requestKey(
+    var registry = newRegistry(SALT_A);
+    var k1 = registry.requestKey(
       "alice@example.com", "env/sys/grp", List.of("bob@example.com"));
-    var k2 = SlackMessageRegistry.requestKey(
+    var k2 = registry.requestKey(
       "alex@example.com", "env/sys/grp", List.of("bob@example.com"));
     assertNotEquals(k1, k2);
   }
 
   @Test
   public void requestKey_distinguishesGroup() {
-    var k1 = SlackMessageRegistry.requestKey(
+    var registry = newRegistry(SALT_A);
+    var k1 = registry.requestKey(
       "alice@example.com", "env/sys/grp-1", List.of("bob@example.com"));
-    var k2 = SlackMessageRegistry.requestKey(
+    var k2 = registry.requestKey(
       "alice@example.com", "env/sys/grp-2", List.of("bob@example.com"));
     assertNotEquals(k1, k2);
   }
 
   @Test
   public void requestKey_distinguishesRecipients() {
-    var k1 = SlackMessageRegistry.requestKey(
+    var registry = newRegistry(SALT_A);
+    var k1 = registry.requestKey(
       "alice@example.com", "env/sys/grp", List.of("bob@example.com"));
-    var k2 = SlackMessageRegistry.requestKey(
+    var k2 = registry.requestKey(
       "alice@example.com", "env/sys/grp", List.of("carol@example.com"));
     assertNotEquals(k1, k2);
   }
 
   @Test
   public void requestKey_emptyRecipientsIsValid() {
+    var registry = newRegistry(SALT_A);
     // Empty recipients shouldn't crash even though no real flow produces it.
-    var k = SlackMessageRegistry.requestKey(
+    var k = registry.requestKey(
       "alice@example.com", "env/sys/grp", List.of());
     assertEquals(64, k.length());
+  }
+
+  /**
+   * Wavemm fork P2-11 regression: the salt MUST influence the output —
+   * otherwise an attacker who reads {(beneficiary, group, recipients)}
+   * from logs could enumerate registry contents by computing SHA-256
+   * themselves. With distinct salts the same input must produce
+   * distinct keys.
+   */
+  @Test
+  public void requestKey_distinguishesSalt() {
+    var registryA = newRegistry(SALT_A);
+    var registryB = newRegistry(SALT_B);
+
+    var inputs = List.of("bob@example.com");
+    var kA = registryA.requestKey("alice@example.com", "env/sys/grp", inputs);
+    var kB = registryB.requestKey("alice@example.com", "env/sys/grp", inputs);
+
+    assertNotEquals(kA, kB,
+      "HMAC under different salts must produce different keys — "
+        + "otherwise the salt has no effect and an attacker who reads "
+        + "input tuples can recover the key with public SHA-256.");
+  }
+
+  @Test
+  public void constructor_rejectsBlankSalt() {
+    // A blank salt would silently produce an HMAC under an empty key,
+    // defeating the secret-derived security property entirely.
+    assertThrows(IllegalArgumentException.class, () -> newRegistry(""));
+    assertThrows(IllegalArgumentException.class, () -> newRegistry("   "));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessages.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessages.java
@@ -77,23 +77,66 @@ public class TestSlackMessages {
   }
 
   @Test
-  public void reviewRequest_escapesBlockquoteFormatting() {
-    // Inject newlines in the justification — they must be escaped so a
-    // crafted message can't break out of the >justification block.
+  public void reviewRequest_rendersJustificationAsPlainText() {
+    // SECURITY: a malicious requester pasting Slack mrkdwn tokens into
+    // the justification field MUST NOT have those tokens interpreted by
+    // Slack — otherwise <!here>/<!channel>, link-spoofing
+    // <https://evil/|innocent text>, or <@Uxxxx> mentions would reach
+    // every reviewer's DM with attacker-controlled formatting. The
+    // justification is rendered via PlainTextObject which Slack treats
+    // as literal text.
+    var hostile = "<!here> URGENT: <https://evil/|click here> *bold* <@U99999>";
     var blocks = SlackMessages.reviewRequest(
       "alice@example.com",
       "env/sys/grp",
-      "line one\nline two",
+      hostile,
       Instant.now().plus(1, ChronoUnit.HOURS),
       URI.create("https://pam.wavemm.net/?activation=jwt"),
       UTC);
 
-    var serialized = blocks.toString();
-    // Expect each new line to begin with a leading > so it stays inside the
-    // blockquote we opened in the template.
-    assertTrue(serialized.contains(">line one\n>line two")
-        || serialized.contains("\\n>line two"),
-      "justification newlines must be escaped to keep blockquote formatting");
+    // Find the SectionBlock that carries the justification — it's a
+    // PlainTextObject (type "plain_text"), distinct from the
+    // mrkdwn-typed "Justification" header section above it.
+    boolean justificationIsPlainText = blocks.stream()
+      .filter(b -> b instanceof com.slack.api.model.block.SectionBlock)
+      .map(b -> (com.slack.api.model.block.SectionBlock) b)
+      .filter(s -> s.getText() != null
+        && s.getText() instanceof com.slack.api.model.block.composition.PlainTextObject)
+      .map(s -> ((com.slack.api.model.block.composition.PlainTextObject) s.getText()).getText())
+      .anyMatch(t -> t.equals(hostile));
+    assertTrue(justificationIsPlainText,
+      "justification must reach Slack as a PlainTextObject so mrkdwn "
+        + "tokens are inert");
+  }
+
+  @Test
+  public void reviewRequest_truncatesOverlongJustification() {
+    // SECURITY/DoS: Block Kit text fields cap at 3000 chars. A 40 KB
+    // justification would otherwise fail the chat.postMessage call for
+    // every reviewer, blocking the elevation entirely.
+    var huge = "x".repeat(50_000);
+    var blocks = SlackMessages.reviewRequest(
+      "alice@example.com",
+      "env/sys/grp",
+      huge,
+      Instant.now().plus(1, ChronoUnit.HOURS),
+      URI.create("https://pam.wavemm.net/?activation=jwt"),
+      UTC);
+
+    var rendered = blocks.stream()
+      .filter(b -> b instanceof com.slack.api.model.block.SectionBlock)
+      .map(b -> (com.slack.api.model.block.SectionBlock) b)
+      .filter(s -> s.getText() != null
+        && s.getText() instanceof com.slack.api.model.block.composition.PlainTextObject)
+      .map(s -> ((com.slack.api.model.block.composition.PlainTextObject) s.getText()).getText())
+      .filter(t -> t.length() > 1)
+      .findFirst()
+      .orElseThrow();
+    assertTrue(rendered.length() <= SlackMessages.justificationMaxLength(),
+      "justification must be truncated to <= JUSTIFICATION_MAX_LENGTH");
+    assertTrue(rendered.endsWith("[truncated]"),
+      "truncation must be visible to reviewers so they don't act on "
+        + "an incomplete justification");
   }
 
   // -------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
@@ -119,6 +119,12 @@ public class TestSlackProposalHandler {
     when(p.group()).thenReturn(GROUP);
     when(p.input()).thenReturn(Map.of("justification", "CASE-123"));
     when(p.expiry()).thenReturn(Instant.now().plus(Duration.ofMinutes(60)));
+    // Default: notify reviewers (= upstream behaviour). Tests covering
+    // the opt-out short-circuit override this with thenReturn(false).
+    // Explicitly stubbing here is required because Proposal#notifyReviewers
+    // is a Java default method, and Mockito returns boolean default
+    // (false) for unstubbed default methods on mocked interfaces.
+    when(p.notifyReviewers()).thenReturn(true);
     return p;
   }
 
@@ -269,6 +275,45 @@ public class TestSlackProposalHandler {
 
     // No siblings to update (we lost the registry), but Alice still gets her DM.
     verify(slack, never()).updateMessage(anyString(), anyString(), anyList(), anyString());
+    verify(slack).lookupUserByEmail(eq("alice@example.com"));
+    verify(slack).postDirectMessage(anyString(), anyList(), anyString());
+  }
+
+  /**
+   * P1-2 regression: when the requester opted out of automated DM
+   * delivery (notifyReviewers=false), no DMs were sent at propose-time
+   * and no Firestore registry entry was ever written. On approval,
+   * the handler must SHORT-CIRCUIT — no registry lookup, no sibling
+   * updates — and only DM the beneficiary. The previous (Phase 2a)
+   * behaviour spuriously WARN-logged "no Slack registry entry" because
+   * the lookup miss looked like a Firestore failure mode.
+   */
+  @Test
+  public void onProposalApproved_optOutShortCircuitsRegistryLookup() throws Exception {
+    var slack = slackClientHappyPath();
+    var registry = mock(SlackMessageRegistry.class);
+    var handler = newHandler(slack, registry, groupResolverPassthrough());
+
+    var approval = mock(JitGroupContext.ApprovalOperation.class);
+    when(approval.user()).thenReturn(BOB);
+
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB, CAROL));
+    when(proposal.notifyReviewers()).thenReturn(false);  // opt-out path
+
+    handler.onProposalApproved(approval, proposal);
+
+    // Critical: no registry round-trip on the opt-out path. The
+    // entry never existed — querying Firestore would just produce
+    // noise.
+    verify(registry, never()).lookup(anyString());
+    verify(registry, never()).delete(anyString());
+
+    // Sibling updates are inherently skipped (no entries to update),
+    // so updateMessage must not fire.
+    verify(slack, never()).updateMessage(anyString(), anyString(), anyList(), anyString());
+
+    // Beneficiary still gets a confirmation DM — that's independent
+    // of how the original notification was delivered.
     verify(slack).lookupUserByEmail(eq("alice@example.com"));
     verify(slack).postDirectMessage(anyString(), anyList(), anyString());
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
@@ -94,6 +94,13 @@ public class TestSlackProposalHandler {
 
   private static SlackMessageRegistry registryHappyPath() {
     var registry = mock(SlackMessageRegistry.class);
+    // Wavemm fork P2-11: requestKey is now an instance method (the
+    // HMAC salt lives on the registry). Stub it to return a stable
+    // string so downstream calls through anyString()/eq() matchers
+    // don't see Mockito's default null and trip NullPointer in
+    // SlackProposalHandler.onOperationProposed.
+    when(registry.requestKey(anyString(), anyString(), anyList()))
+      .thenReturn("test-fingerprint-key");
     when(registry.record(anyString(), anyList(), any()))
       .thenReturn(CompletableFuture.completedFuture(null));
     when(registry.lookup(anyString()))
@@ -232,6 +239,8 @@ public class TestSlackProposalHandler {
         "bob@example.com", "U-BOB", "C-BOB", "111.111"),
       new SlackMessageRegistry.ReviewerMessage(
         "carol@example.com", "U-CAROL", "C-CAROL", "222.222"));
+    when(registry.requestKey(anyString(), anyString(), anyList()))
+      .thenReturn("test-fingerprint-key");
     when(registry.lookup(anyString()))
       .thenReturn(CompletableFuture.completedFuture(Optional.of(entries)));
     when(registry.delete(anyString()))
@@ -262,6 +271,8 @@ public class TestSlackProposalHandler {
   public void onProposalApproved_stillNotifiesBeneficiaryOnRegistryMiss() throws Exception {
     var slack = slackClientHappyPath();
     var registry = mock(SlackMessageRegistry.class);
+    when(registry.requestKey(anyString(), anyString(), anyList()))
+      .thenReturn("test-fingerprint-key");
     when(registry.lookup(anyString()))
       .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
     var handler = newHandler(slack, registry, groupResolverPassthrough());
@@ -292,6 +303,8 @@ public class TestSlackProposalHandler {
   public void onProposalApproved_optOutShortCircuitsRegistryLookup() throws Exception {
     var slack = slackClientHappyPath();
     var registry = mock(SlackMessageRegistry.class);
+    when(registry.requestKey(anyString(), anyString(), anyList()))
+      .thenReturn("test-fingerprint-key");
     var handler = newHandler(slack, registry, groupResolverPassthrough());
 
     var approval = mock(JitGroupContext.ApprovalOperation.class);
@@ -316,5 +329,72 @@ public class TestSlackProposalHandler {
     // of how the original notification was delivered.
     verify(slack).lookupUserByEmail(eq("alice@example.com"));
     verify(slack).postDirectMessage(anyString(), anyList(), anyString());
+  }
+
+  // ---------------------------------------------------------------------
+  // Options — fan-out concurrency cap (wavemm fork P1-4)
+  // ---------------------------------------------------------------------
+
+  @Test
+  public void options_singleArgConstructor_appliesDefaultFanOutCap() {
+    var opts = new SlackProposalHandler.Options(ZoneId.of("UTC"));
+    assertEquals(
+      SlackProposalHandler.Options.DEFAULT_MAX_CONCURRENT_FAN_OUT,
+      opts.maxConcurrentFanOut(),
+      "single-arg ctor must default to DEFAULT_MAX_CONCURRENT_FAN_OUT "
+        + "so existing call sites get a sane cap without code change");
+  }
+
+  @Test
+  public void options_rejectsNonPositiveFanOutCap() {
+    // A 0 or negative cap would cause the Semaphore to deadlock the
+    // first acquire — fail fast at construction time instead.
+    assertThrows(IllegalArgumentException.class,
+      () -> new SlackProposalHandler.Options(ZoneId.of("UTC"), 0));
+    assertThrows(IllegalArgumentException.class,
+      () -> new SlackProposalHandler.Options(ZoneId.of("UTC"), -1));
+  }
+
+  /**
+   * P1-4 regression: a policy ACL granting APPROVE_OTHERS to a 50+
+   * member group used to launch one parallel Slack call chain per
+   * member, capable of saturating Slack's chat.postMessage Tier 4
+   * quota. With the Semaphore in {@link SlackProposalHandler}, in-flight
+   * call chains are bounded — verify that with 30 reviewers the call
+   * still completes (no deadlock) and every reviewer ultimately gets
+   * a DM (no permits leak).
+   */
+  @Test
+  public void onOperationProposed_fanOutHonoursConcurrencyCap() throws Exception {
+    var slack = slackClientHappyPath();
+    var registry = registryHappyPath();
+    var handler = newHandler(slack, registry, groupResolverPassthrough());
+
+    Set<IamPrincipalId> reviewers = new java.util.HashSet<>();
+    for (int i = 0; i < 30; i++) {
+      reviewers.add(new EndUserId("reviewer-" + i + "@example.com"));
+    }
+
+    // Call into onOperationProposed directly to mirror the existing
+    // tests in this class (the parent's `propose()` exercises the
+    // tokenSigner mock too, which would return null and NPE — out of
+    // scope here).
+    handler.onOperationProposed(
+      operationFor(ALICE),
+      proposalFor(ALICE, reviewers),
+      tokenFor(reviewers),
+      ACTION_URI);
+
+    // Every reviewer must receive exactly one DM — proves the
+    // Semaphore-gated fan-out doesn't drop or duplicate work and
+    // that permits are returned even on the happy path.
+    verify(slack, times(30))
+      .postDirectMessage(anyString(), anyList(), anyString());
+
+    var entriesCaptor = ArgumentCaptor.forClass(List.class);
+    verify(registry).record(anyString(), entriesCaptor.capture(), any());
+    assertEquals(30, entriesCaptor.getValue().size(),
+      "registry must record one entry per reviewer regardless of "
+        + "fan-out concurrency cap");
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
@@ -76,6 +76,7 @@ public class TestGroupsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -93,6 +94,7 @@ public class TestGroupsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -122,6 +124,7 @@ public class TestGroupsResource {
         new IamRoleBinding(new ProjectId("project-1"), new IamRole("roles/role-1"), "description", "condition")));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -157,6 +160,7 @@ public class TestGroupsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -182,6 +186,7 @@ public class TestGroupsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -204,6 +209,7 @@ public class TestGroupsResource {
       Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -234,6 +240,7 @@ public class TestGroupsResource {
       ));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -264,6 +271,7 @@ public class TestGroupsResource {
       ));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -297,6 +305,7 @@ public class TestGroupsResource {
       ));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -325,6 +334,7 @@ public class TestGroupsResource {
       Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -349,6 +359,7 @@ public class TestGroupsResource {
       Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -360,7 +371,7 @@ public class TestGroupsResource {
       group.id().name(),
       new MultivaluedHashMap<>());
 
-    verify(resource.proposalHandler, never()).propose(any(), any());
+    verify(resource.proposalHandler, never()).propose(any(), any(), any());
     verify(resource.auditTrail, times(1)).joinExecuted(
       any(JitGroupContext.JoinOperation.class),
       any(Principal.class));
@@ -381,12 +392,13 @@ public class TestGroupsResource {
       Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
     resource.proposalHandler = Mockito.mock(ProposalHandler.class);
 
-    when(resource.proposalHandler.propose(any(), any()))
+    when(resource.proposalHandler.propose(any(), any(), any()))
       .thenReturn(new ProposalHandler.ProposalToken(
         "token",
         Set.of(SAMPLE_APPROVING_USER),
@@ -398,7 +410,7 @@ public class TestGroupsResource {
       group.id().name(),
       new MultivaluedHashMap<>());
 
-    verify(resource.proposalHandler, times(1)).propose(any(), any());
+    verify(resource.proposalHandler, times(1)).propose(any(), any(), any());
     verify(resource.auditTrail, times(1)).joinProposed(
       any(JitGroupContext.JoinOperation.class),
       any(ProposalHandler.ProposalToken.class));
@@ -407,6 +419,138 @@ public class TestGroupsResource {
     assertFalse(groupInfo.join().membership().active());
     assertEquals(0, groupInfo.join().satisfiedConstraints().size());
     assertEquals(0, groupInfo.join().unsatisfiedConstraints().size());
+  }
+
+  // -------------------------------------------------------------------------
+  // Wavemm fork: picker-UX tests (Phase 2b/3).
+  // -------------------------------------------------------------------------
+
+  /**
+   * P0-1 regression: a hostile requester submits {@code selectedReviewers}
+   * naming an email that's NOT in the qualified-peer set. The validation
+   * step in {@code post} must reject before {@code propose} is called.
+   */
+  @Test
+  public void post_whenSelectedReviewersIncludeUnauthorisedEmail_rejectsWith403()
+    throws Exception {
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .allow(SAMPLE_APPROVING_USER, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+
+    var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+    resource.proposalHandler = Mockito.mock(ProposalHandler.class);
+    resource.subject = Subjects.create(SAMPLE_USER);
+    resource.executor = Runnable::run;
+    resource.groupsClient = Mockito.mock(
+      com.google.solutions.jitaccess.apis.clients.CloudIdentityGroupsClient.class);
+    when(resource.groupsClient.listMembershipsByUser(any()))
+      .thenReturn(java.util.List.of());
+
+    var inputs = new MultivaluedHashMap<String, String>();
+    inputs.put(GroupsResource.FIELD_SELECTED_REVIEWERS,
+      List.of("attacker@external.com"));
+
+    var thrown = assertThrows(AccessDeniedException.class, () ->
+      resource.post(
+        group.id().environment(),
+        group.id().system(),
+        group.id().name(),
+        inputs));
+    assertTrue(thrown.getMessage().contains("attacker@external.com"));
+
+    // Critical: never reach the proposal handler when validation fails.
+    verify(resource.proposalHandler, never()).propose(any(), any(), any());
+  }
+
+  @Test
+  public void parseSelectedReviewers_capsAtFifty() {
+    // Above the cap → BadRequestException; private-method coverage via
+    // the public POST since parseSelectedReviewers is package-private.
+    var raw = new java.util.ArrayList<String>();
+    for (int i = 0; i < 51; i++) raw.add("user-" + i + "@example.com");
+
+    var inputs = new MultivaluedHashMap<String, String>();
+    inputs.put(GroupsResource.FIELD_SELECTED_REVIEWERS, raw);
+
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+    var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+
+    assertThrows(jakarta.ws.rs.BadRequestException.class, () ->
+      resource.post(
+        group.id().environment(),
+        group.id().system(),
+        group.id().name(),
+        inputs));
+  }
+
+  @Test
+  public void post_whenNotifyReviewersFalse_passesOptionToProposeAndReturnsApprovalUrl()
+    throws Exception {
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+
+    var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(true);  // copy-link mode on
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+    resource.proposalHandler = Mockito.mock(ProposalHandler.class);
+    // copy-link mode reaches through buildActionUri.apply(...) to build
+    // the approvalUrl in the response, so linkBuilder + uriInfo need
+    // working stubs unlike the non-copy-link tests above.
+    resource.linkBuilder = uriInfo -> jakarta.ws.rs.core.UriBuilder
+      .fromUri("https://example.test/");
+    resource.uriInfo = Mockito.mock(jakarta.ws.rs.core.UriInfo.class);
+
+    when(resource.proposalHandler.propose(any(), any(), any()))
+      .thenReturn(new ProposalHandler.ProposalToken(
+        // TokenObfuscator.encode requires a JWT-shaped string ("ey..." +
+        // dot-segments), so a literal "stub-jwt" trips its preconditions
+        // when copy-link mode actually applies the buildActionUri.
+        "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.",
+        Set.of(SAMPLE_APPROVING_USER), Instant.MAX));
+
+    var inputs = new MultivaluedHashMap<String, String>();
+    // Hidden-then-checkbox pattern: only the hidden's "false" present
+    // ⇒ user unchecked the toggle ⇒ notifyReviewers must propagate
+    // false to the handler.
+    inputs.put(GroupsResource.FIELD_NOTIFY_REVIEWERS, List.of("false"));
+
+    var groupInfo = resource.post(
+      group.id().environment(),
+      group.id().system(),
+      group.id().name(),
+      inputs);
+
+    var captor = org.mockito.ArgumentCaptor.forClass(
+      ProposalHandler.ProposeOptions.class);
+    verify(resource.proposalHandler).propose(any(), any(), captor.capture());
+    assertFalse(captor.getValue().notifyReviewers(),
+      "ProposeOptions.notifyReviewers must reflect the form field");
+
+    assertNotNull(groupInfo.join().approvalUrl(),
+      "copy-link mode + JOIN_PROPOSED must surface the approval URL");
   }
 
   //---------------------------------------------------------------------------
@@ -418,6 +562,7 @@ public class TestGroupsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = createCatalog(group);
@@ -435,6 +580,7 @@ public class TestGroupsResource {
     var groupId = new JitGroupId("env-1", "system-1", "group-1");
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = Mockito.mock(Catalog.class);
@@ -458,6 +604,7 @@ public class TestGroupsResource {
       .thenReturn(Optional.empty());
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
     resource.catalog = Mockito.mock(Catalog.class);
@@ -481,6 +628,7 @@ public class TestGroupsResource {
       .thenReturn(Optional.of(new GroupKey("abc")));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.consoles = new Consoles(new OrganizationId("123"));
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
@@ -510,6 +658,7 @@ public class TestGroupsResource {
       .thenReturn(new GroupId("group@example.com"));
 
     var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
     resource.consoles = new Consoles(new OrganizationId("123"));
     resource.logger = Mockito.mock(Logger.class);
     resource.auditTrail = Mockito.mock(OperationAuditTrail.class);

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestGroupsResource.java
@@ -411,9 +411,14 @@ public class TestGroupsResource {
       new MultivaluedHashMap<>());
 
     verify(resource.proposalHandler, times(1)).propose(any(), any(), any());
+    // Wavemm fork P1-8/P2-10: 3-arg overload carries the
+    // notifyReviewers boolean so the audit log can split copy-link
+    // from the regular DM-everyone flow. Unchecked POST → defaults
+    // to true, matching upstream semantics.
     verify(resource.auditTrail, times(1)).joinProposed(
       any(JitGroupContext.JoinOperation.class),
-      any(ProposalHandler.ProposalToken.class));
+      any(ProposalHandler.ProposalToken.class),
+      eq(true));
 
     assertEquals(GroupsResource.JoinStatusInfo.JOIN_PROPOSED, groupInfo.join().status());
     assertFalse(groupInfo.join().membership().active());
@@ -500,6 +505,49 @@ public class TestGroupsResource {
         inputs));
   }
 
+  /**
+   * Wavemm fork P2-9: malformed email entries in the picker submission
+   * (e.g. "@@@@", "user@", "spaces in@email.com") used to slip through
+   * the old "contains @" check and become {@code EndUserId} instances
+   * that propagated to audit logs and downstream ACL diffs. The
+   * stricter regex-backed parse rejects them at the REST boundary.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "@@@@",
+    "user@",
+    "@example.com",
+    "no-at-sign",
+    "spaces in@example.com",
+    "user@host with spaces"
+  })
+  public void parseSelectedReviewers_rejectsMalformedEmails(String hostile) {
+    var inputs = new MultivaluedHashMap<String, String>();
+    inputs.put(GroupsResource.FIELD_SELECTED_REVIEWERS, List.of(hostile));
+
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.JOIN.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+    var resource = new GroupsResource();
+    resource.options = new GroupsResource.Options(false);
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+
+    var ex = assertThrows(
+      jakarta.ws.rs.BadRequestException.class,
+      () -> resource.post(
+        group.id().environment(),
+        group.id().system(),
+        group.id().name(),
+        inputs));
+    assertTrue(ex.getMessage().contains("selectedReviewers"),
+      "rejection message must name the field; got: " + ex.getMessage());
+  }
+
   @Test
   public void post_whenNotifyReviewersFalse_passesOptionToProposeAndReturnsApprovalUrl()
     throws Exception {
@@ -549,8 +597,72 @@ public class TestGroupsResource {
     assertFalse(captor.getValue().notifyReviewers(),
       "ProposeOptions.notifyReviewers must reflect the form field");
 
+    // Wavemm fork P1-8/P2-10: the audit-trail event must carry
+    // notifyReviewers=false so the BigQuery sink can slice copy-link
+    // out of the regular DM-everyone propose flow.
+    verify(resource.auditTrail).joinProposed(
+      any(JitGroupContext.JoinOperation.class),
+      any(ProposalHandler.ProposalToken.class),
+      eq(false));
+
     assertNotNull(groupInfo.join().approvalUrl(),
       "copy-link mode + JOIN_PROPOSED must surface the approval URL");
+  }
+
+  //---------------------------------------------------------------------------
+  // getReviewers — rate limit (wavemm fork P1-4).
+  //---------------------------------------------------------------------------
+
+  /**
+   * The reviewer picker calls into ReviewerCandidates which itself
+   * does one listMembershipsByUser + a parallel listMemberships
+   * fan-out. A polling client could therefore burn through the JIT
+   * SA's Cloud Identity quota and DoS legitimate elevations. We
+   * cap to {@link GroupsResource#REVIEWERS_RATE_PER_SECOND} per
+   * second per authenticated user, with a burst allowance — verify
+   * here that exhausting the burst and then asking for one more
+   * permit fails (drives the 429 path in the resource method).
+   */
+  @Test
+  public void getReviewers_rateLimitTripsOnPolling() {
+    GroupsResource.clearReviewerRateLimiters();
+    var limiter = GroupsResource.rateLimiterFor("ratelimit-test@example.com");
+
+    // The Guava SmoothBursty limiter starts with one permit available;
+    // additional permits are accrued at REVIEWERS_RATE_PER_SECOND. The
+    // first acquire must succeed (covers the "single picker open"
+    // case), and a tight loop right after must trip the limit (covers
+    // the "polling client" case). Without sleeps in the test we don't
+    // assert the *exact* burst capacity — only that the limiter
+    // rejects sustained polling, which is the security-relevant
+    // property.
+    assertTrue(limiter.tryAcquire(),
+      "first call after a quiet period must always succeed");
+
+    boolean rejected = false;
+    for (int i = 0; i < 200; i++) {
+      if (!limiter.tryAcquire()) {
+        rejected = true;
+        break;
+      }
+    }
+    assertTrue(rejected,
+      "a tight 200-call loop must hit the rate limit at least once "
+        + "— otherwise a polling frontend can exhaust Cloud Identity quota");
+  }
+
+  @Test
+  public void getReviewers_rateLimitIsPerUser() {
+    GroupsResource.clearReviewerRateLimiters();
+    var alice = GroupsResource.rateLimiterFor("alice@example.com");
+    var bob = GroupsResource.rateLimiterFor("bob@example.com");
+
+    // Drain alice's permits
+    while (alice.tryAcquire()) { /* burn */ }
+
+    assertTrue(bob.tryAcquire(),
+      "bob's bucket must be independent of alice's — otherwise one "
+        + "noisy user can DoS every other user's picker");
   }
 
   //---------------------------------------------------------------------------

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestInputs.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestInputs.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class TestInputs {
@@ -95,5 +96,49 @@ public class TestInputs {
 
     verify(property1, times(1)).set(eq("1"));
     verify(property2, times(1)).set(eq("2"));
+  }
+
+  /**
+   * Wavemm fork P0-1: defense-in-depth absolute cap on per-input
+   * length. Rejects oversize submissions at the REST boundary so a
+   * misconfigured (or unbounded) {@code maxLength} in a policy YAML
+   * can't let a hostile requester ship multi-MB justifications into
+   * Slack DMs / Firestore docs / audit logs.
+   */
+  @Test
+  public void copyValues_whenValueExceedsAbsoluteCap_throws() {
+    var huge = "x".repeat(Inputs.INPUT_MAX_LENGTH + 1);
+    var source = new MultivaluedHashMap<String, String>();
+    source.add("justification", huge);
+
+    var property = Mockito.mock(Property.class);
+    when(property.name()).thenReturn("justification");
+    when(property.displayName()).thenReturn("Justification");
+    when(property.isRequired()).thenReturn(true);
+
+    var ex = assertThrows(
+      IllegalArgumentException.class,
+      () -> Inputs.copyValues(source, List.of(property)));
+
+    // Confirm the cap fires before delegating to property.set — without
+    // this, a policy that forgot to set maxLength would still let the
+    // value through.
+    verify(property, never()).set(anyString());
+    assertTrue(ex.getMessage().contains("Justification"),
+      "error must name the field so the requester can fix the input");
+  }
+
+  @Test
+  public void copyValues_whenValueAtCapBoundary_passes() {
+    var atCap = "x".repeat(Inputs.INPUT_MAX_LENGTH);
+    var source = new MultivaluedHashMap<String, String>();
+    source.add("justification", atCap);
+
+    var property = Mockito.mock(Property.class);
+    when(property.name()).thenReturn("justification");
+    when(property.isRequired()).thenReturn(true);
+
+    Inputs.copyValues(source, List.of(property));
+    verify(property, times(1)).set(eq(atCap));
   }
 }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestSystemsResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestSystemsResource.java
@@ -70,6 +70,7 @@ public class TestSystemsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 
@@ -83,6 +84,7 @@ public class TestSystemsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 
@@ -96,6 +98,7 @@ public class TestSystemsResource {
     var group = Policies.createJitGroupPolicy("g-1", AccessControlList.EMPTY, Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 
@@ -124,6 +127,7 @@ public class TestSystemsResource {
     environment.add(system);
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(environment, Subjects.create(SAMPLE_USER));
 
@@ -167,6 +171,7 @@ public class TestSystemsResource {
     environment.add(system);
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(environment, Subjects.create(SAMPLE_USER));
 
@@ -216,6 +221,7 @@ public class TestSystemsResource {
     environment.add(system);
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(environment, Subjects.create(SAMPLE_USER));
 
@@ -243,6 +249,7 @@ public class TestSystemsResource {
         new Principal(group.id(), expiry)));
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment(), subject);
 
@@ -267,6 +274,7 @@ public class TestSystemsResource {
       Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 
@@ -290,6 +298,7 @@ public class TestSystemsResource {
       Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 
@@ -315,6 +324,7 @@ public class TestSystemsResource {
       Map.of());
 
     var resource = new SystemsResource();
+    resource.groupsOptions = new GroupsResource.Options(false);
     resource.logger = Mockito.mock(Logger.class);
     resource.catalog = createCatalog(group.system().environment());
 


### PR DESCRIPTION
End-to-end change covering both halves of the picker UX in one PR. Default behaviour stays identical to Phase 2a (no picker selection → notify all qualified peers), so this is safe to deploy even before the frontend opts users into the picker.

The PR now also carries a security-hardening pass that addresses every P0/P1/P2 finding from the senior-security-engineer review (modulo three explicitly accepted: P1-5, P2-12, P2-14). See the **Security hardening** section below.

## Backend

### `ProposalHandler` interface
Now takes a `ProposeOptions` record carrying two per-request flags:
- **`reviewerFilter`** — narrow recipients to a requester-selected subset. `JoinOperation.propose` intersects with the policy ACL so a stale picker selection naming a non-approver is silently dropped, never widened.
- **`notifyReviewers`** — when false, the JWT is generated and signed, but `onOperationProposed` is skipped. Requester gets the approval URL to share manually.

Upstream 2-arg `propose` is now a default method delegating to the 3-arg form, so existing subclasses (Debug/MailProposalHandler) and tests don't break.

### `JoinOperation.propose`
Gains a `Set<EndUserId>` filter overload. The 1-arg upstream form delegates with null. Filter is applied to the APPROVE_OTHERS-derived set; group principals pass through (expanded later by the proposal handler).

### `GroupsResource`
- **New `GET /reviewers`** returns candidate peer reviewers with a `suggested` flag for those sharing an approver group with the requester. Backed by `ReviewerCandidates` helper that uses 2+M API calls (listMembershipsByUser on requester + group expansion on shared approver groups) instead of O(N) per-candidate lookups — important when ACLs name broad groups like `engineering@`.
- **`POST`** now extracts `selectedReviewers[]` and `notifyReviewers` form fields and threads them through `ProposeOptions`.
- **`JoinInfo`** gains `approvalUrl` + `copyLinkEnabled`, both gated by new `SLACK_COPY_LINK_ENABLED` env var.

## Frontend (vanilla JS + jQuery + MDC, upstream style)

`GroupInfoView._bind` fetches `/reviewers` and renders a checkbox list under the join form when status is `JOIN_ALLOWED_WITH_APPROVAL`:
- Suggested teammates are pre-checked + highlighted with a "team" badge
- Search input filters list client-side
- When `copyLinkEnabled=true`: "Notify selected reviewers in Slack" toggle (hidden+checkbox pair) + copy-able `approvalUrl` box on submit response with Clipboard API + text-select fallback

If `/reviewers` fails the picker silently degrades — form still submits, backend defaults to notifying every qualified peer (= Phase 2a behaviour).

## Security hardening (P0/P1/P2 findings)

| ID | Fix |
|---|---|
| **P0-1** | `SlackMessages`: justification rendered as `PlainTextObject` (mrkdwn-inert), capped at 2.5 KB with visible `[truncated]` suffix. `Inputs.copyValues`: defense-in-depth absolute per-input cap (`INPUT_MAX_LENGTH=16384`) at the REST boundary so a misconfigured/unbounded policy can't ship multi-MB justifications. |
| **P1-4** | `SlackProposalHandler`: Semaphore-gated per-reviewer fan-out (`Options.maxConcurrentFanOut`, default 8) bounds chat.postMessage pressure on Slack Tier 4. `GroupsResource.getReviewers`: per-user Guava `RateLimiter` (1 req/s, ~1s burst) backing `GET /reviewers` so a polling client can't burn the SA's Cloud Identity quota. |
| **P1-6** | Catalog-side defense-in-depth in `JitGroupContext.JoinOperation.propose`: when the policy ACL has no `GroupId` approver, reject `reviewerFilter` entries that aren't in the direct ACL. ACL-with-group still trusts the REST layer's expansion check. |
| **P1-7** | `GroupResolver.expand` Javadoc: visibility comment + caller-audit list, emphasising it is **not** itself an authorisation decision. |
| **P1-8 / P2-10** | `OperationAuditTrail.joinProposed`: 3-arg overload taking `notifyReviewers`. Emits a new `proposal/notify_reviewers` label and "via copy-link" message body when false, so the BigQuery sink can slice approval requests not visible to the normal reviewer set. |
| **P2-9** | `parseSelectedReviewers` regex `^[^@\s]+@[^@\s]+\.[^@\s]+$` rejects `@@@@`, multi-`@` strings, embedded whitespace, missing TLDs that the previous `contains("@")` check accepted. |
| **P2-11** | `SlackMessageRegistry.requestKey`: HMAC-SHA-256 (was bare SHA-256) under a Secret Manager-backed salt (`SLACK_REGISTRY_KEY_SALT_SECRET`). `requestKey` is now an instance method; constructor rejects a blank salt. The wavemm-iam parent PR provisions the secret + IAM grant. |
| **P2-13** | `application.properties`: pin `com.slack.api` log level to `INFO` so a future DEBUG-everything operator can't leak the Bearer xoxb-… token into Cloud Logging. `pom.xml`: OWASP dependency-check 11.1.1 plugin (`failBuildOnCVSS=8`, unbound to default phases). |

P1-3 (bot-token rotation runbook) and P0-2 (Firestore IAM scope honest-comment) live in the wavemm-iam parent PR alongside the matching Terraform.

**Explicitly skipped** per maintainer call: P1-5 (PII redaction in logs), P2-12 (dual-approver race test), P2-14 (0-test-mpa-flow cleanup).

## Build

`pom.xml` → `2.3.0-wavemm.6`. Forces new App Engine `version_id` so env-var-only changes (e.g. flipping `SLACK_COPY_LINK_ENABLED`) propagate.

## Tests updated

- `TestGroupsResource`: new injected `options` field, 3-arg `propose` Mockito stubs, rate-limit + email-validation regression tests.
- `TestAbstractProposalHandler`: 2-arg `JoinOperation.propose` mock signature.
- `TestSlackMessages`: PlainTextObject + truncation regression tests.
- `TestSlackMessageRegistry`: HMAC salt-distinguishes-keys + blank-salt-rejection tests.
- `TestSlackProposalHandler`: concurrency-cap + Options-validation tests.
- `TestJitGroupContext`: catalog-side filter validation tests (direct-ACL reject + group-ACL trust).
- `TestOperationAuditTrail`: copy-link branch label + message body tests.
- `TestInputs`: per-input length cap test.

**1008/1008 unit tests green locally** (`mvn -DskipITs test`).

Existing test assertions about `JoinInfo` keep passing — new fields default to null/false on legacy paths.

## Companion PR
Parent-repo bump + Terraform changes: wavemm/wavemm-iam#290

🤖 Generated with [Claude Code](https://claude.com/claude-code)