### PR TITLE
slack DM: warn reviewers about IAP roundtrip dropping the action URL

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0-wavemm.6</version>
+  <version>2.3.0-wavemm.7</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
@@ -117,7 +117,23 @@ final class SlackMessages {
     blocks.add(ContextBlock.builder()
       .elements(List.of(markdown(
         ":eyes: Approval is final — review the request carefully. "
-          + "Approving opens the JIT page where you confirm.")))
+          + "Approving opens the JIT page where you confirm.\n"
+          //
+          // IAP roundtrip caveat — the first click in a fresh browser
+          // session can drop the action URL's query string during the
+          // Google sign-in redirect, landing the reviewer on the JIT
+          // homepage instead of the proposal-acceptance view. Clicking
+          // the Slack button a second time replays the URL with a
+          // valid IAP cookie and works. Documenting this inline because
+          // we don't control the IAP redirect contract; until Google
+          // preserves query strings reliably across the OAuth roundtrip
+          // (or we add frontend detection of "homepage but came from
+          // accounts.google.com"), telling reviewers to click again is
+          // the cheapest fix.
+          + ":information_source: First click after a long break may "
+          + "land you on the JIT homepage instead of the approval page "
+          + "(IAP login). If so, just click \"Approve in JIT\" again "
+          + "from this message — your IAP cookie is now fresh.")))
       .build());
 
     return blocks;


### PR DESCRIPTION
## Summary

Reported by a reviewer (Nico, post-merge of #9):

> Small UX thing about the links to be aware of: when I clicked on the link, I was first asked to sign-in with google; once signed-in, I was on the pam homepage. So I went back to this message to click the link again to get the runin-prod-ro permission.

Root cause: IAP's OAuth roundtrip during the first sign-in in a fresh browser session occasionally strips the action URL's query string (which is where the proposal token lives — `?f=/environments/.../proposal/{token}`). The reviewer lands on `pam.wavemm.net/` (homepage) instead of the proposal-acceptance view. Clicking the Slack button again works because the IAP cookie is now fresh.

We don't directly control the IAP redirect contract, so the cheapest fix is to tell reviewers inline what to do. Adding a one-liner to the existing ContextBlock under the "Approve in JIT" button.

## Diff

The new line appended to the existing context message:

> :information_source: First click after a long break may land you on the JIT homepage instead of the approval page (IAP login). If so, just click "Approve in JIT" again from this message — your IAP cookie is now fresh.

## Future improvements (out of scope)

- Frontend detection: if `view.js` sees the page loaded without a `?f=` param but the `Referer` is `accounts.google.com`, render an explicit banner. More work.
- Server-side: pass the original URL as `state` in the OAuth roundtrip. Would require IAP/load-balancer config we don't fully own.

## Test plan

- [ ] Visual smoke-test on rev URL after deploy: submit an MPA elevation, verify the reviewer DM contains the new line in the context block.
- [ ] No new unit tests — the existing tests don't assert on the literal context-block prose, so the change is invisible to the test suite (intentional: the prose is presentation-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)