### PR TITLE
Guard IAP brand and client against destructive replaces

### DIFF
--- a/terraform/jitgroups-appengine/main.tf
+++ b/terraform/jitgroups-appengine/main.tf
@@ -260,10 +260,13 @@ resource "google_iap_brand" "iap_brand" {
     project                    = var.project_id
     support_email              = var.admin_email
     application_title          = "JIT Groups"
-    # lifecycle {
-    #     # This resource can't be deleted.
-    #     prevent_destroy = true
-    # }
+    lifecycle {
+        # Brands cannot be deleted or recreated (one per project, and the
+        # IAP OAuth Admin API is deprecated). A support_email change forces
+        # replacement, which first deletes the dependent IAP client and
+        # breaks all logins (2026-07-07 outage). Fail the plan instead.
+        prevent_destroy = true
+    }
 }
 
 #
@@ -272,6 +275,12 @@ resource "google_iap_brand" "iap_brand" {
 resource "google_iap_client" "iap_client" {
     display_name               = "JIT Groups"
     brand                      = google_iap_brand.iap_brand.name
+
+    # Never delete the live OAuth client through the API: App Engine IAP
+    # keeps referencing it and every login fails with `deleted_client`
+    # (2026-07-07 outage). On destroy/replace, only remove it from state
+    # and leave the client running in GCP.
+    deletion_policy            = "ABANDON"
 }
 
 #


### PR DESCRIPTION
## Why

During the 2026-07-07 incident (wavemm-iam#325 → #327), changing `admin_email` forced a replacement of `google_iap_brand`. Brands can't be deleted or recreated (one per project, IAP OAuth Admin API deprecated), but the replace attempt **deleted the live `google_iap_client` first**, breaking every PAM login with `Error 401: deleted_client` for ~5.5h until the brand and a replacement client were imported back into state.

## What

- **Brand: `prevent_destroy = true`** (uncomments the existing hint) — any plan that would replace the brand now fails at plan time, before touching GCP.
- **Client: `deletion_policy = "ABANDON"`** — destroys/replaces leave the client running in GCP and only remove it from state, so IAP never ends up pointing at a deleted client.

`terraform validate` passes (google provider v7). No change to the app sources zip, so bumping the submodule in wavemm-iam won't trigger a redeploy — only a metadata-only apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)