### PR TITLE
[i,l,-r] Slack approval follow-ups: single-use JWTs, approver DM update, picker copy (SECOP-1093/1094/1095)

### DIFF
--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.solutions</groupId>
   <artifactId>jitaccess</artifactId>
-  <version>2.3.0-wavemm.8</version>
+  <version>2.3.0-wavemm.9</version>
   <properties>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>

--- a/sources/src/main/java/com/google/solutions/jitaccess/catalog/Proposal.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/catalog/Proposal.java
@@ -88,6 +88,18 @@ public interface Proposal {
   }
 
   /**
+   * Wavemm fork (SECOP-1093): stable, unpredictable identifier of this
+   * proposal — for token-backed proposals, the JWT {@code jti} claim.
+   * Used to record consumption so an approval link can be used exactly
+   * once. {@code null} when the proposal implementation has no such
+   * identifier; consumers must treat that as "consumption tracking not
+   * available" and skip enforcement rather than fail.
+   */
+  default String id() {
+    return null;
+  }
+
+  /**
    * Invoked when the proposal was completed successfully.
    */
   void onCompleted(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/AbstractProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/AbstractProposalHandler.java
@@ -207,6 +207,13 @@ public abstract class AbstractProposalHandler implements ProposalHandler {
       }
 
       @Override
+      public String id() {
+        // The jti minted at propose-time: 6 crypto-random bytes, base64.
+        // Anchors single-use consumption tracking (SECOP-1093).
+        return payload.getJwtId();
+      }
+
+      @Override
       public @NotNull JitGroupId group() {
         return group;
       }

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/ProposalHandler.java
@@ -93,6 +93,32 @@ public interface ProposalHandler {
   ) throws AccessException;
 
   /**
+   * Wavemm fork (SECOP-1093): reject proposals whose token was already
+   * used to approve. Proposal tokens are stateless JWTs — without a
+   * consumption record, one approval link authorizes unlimited re-grants
+   * for the token lifetime (~1h), each resetting the membership clock.
+   *
+   * <p>The default is a no-op: handlers without a consumption store
+   * (mail, debug) keep the upstream replayable semantics. The Slack
+   * handler enforces via its Firestore registry.
+   *
+   * @throws AccessException when the proposal was already consumed
+   */
+  default void verifyNotConsumed(@NotNull Proposal proposal)
+    throws AccessException {
+  }
+
+  /**
+   * Wavemm fork (SECOP-1093): record that this proposal was used to
+   * approve, so subsequent {@link #verifyNotConsumed} calls reject it.
+   * Best-effort by contract — implementations must not fail the
+   * approval that just succeeded; a missed mark merely restores the
+   * upstream replayable behaviour for this one token.
+   */
+  default void markConsumed(@NotNull Proposal proposal) {
+  }
+
+  /**
    * Token that encodes all information about a proposal in a tamper-proof
    * way, suitable for exchanging in URLs and/or email messages.
    */

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessageRegistry.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessageRegistry.java
@@ -56,6 +56,7 @@ public class SlackMessageRegistry {
   static final String COLLECTION = "requests";
   static final String FIELD_REVIEWERS = "reviewers";
   static final String FIELD_EXPIRES_AT = "expires_at";
+  static final String FIELD_CONSUMED = "consumed";
 
   private final @NotNull Firestore firestore;
   private final @NotNull Executor executor;
@@ -131,6 +132,21 @@ public class SlackMessageRegistry {
       beneficiary,
       groupId,
       String.join(",", sorted));
+    return hmacHex(canonical);
+  }
+
+  /**
+   * Key of the consumption marker for a proposal JWT (SECOP-1093).
+   * Namespaced with a prefix so it can never collide with a
+   * {@link #requestKey} in the shared collection, and HMAC'd for the
+   * same reason request keys are: a Firestore reader without the salt
+   * can't correlate markers with tokens they've seen.
+   */
+  public @NotNull String consumptionKey(@NotNull String proposalId) {
+    return hmacHex("consumed|" + proposalId);
+  }
+
+  private @NotNull String hmacHex(@NotNull String canonical) {
     try {
       var mac = Mac.getInstance("HmacSHA256");
       mac.init(new SecretKeySpec(this.hmacKey, "HmacSHA256"));
@@ -220,6 +236,54 @@ public class SlackMessageRegistry {
         throw new RuntimeException(
           "Failed to read Slack message registry entry " + requestKey, e);
       }
+    }, this.executor);
+  }
+
+  /**
+   * Check whether a proposal was already used to approve (SECOP-1093).
+   * Missing document → not consumed.
+   */
+  public @NotNull CompletableFuture<Boolean> isProposalConsumed(
+    @NotNull String consumptionKey
+  ) {
+    return CompletableFutures.supplyAsync(() -> {
+      try {
+        return collection().document(consumptionKey).get().get().exists();
+      }
+      catch (InterruptedException | ExecutionException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(
+          "Failed to read proposal consumption marker " + consumptionKey, e);
+      }
+    }, this.executor);
+  }
+
+  /**
+   * Record that a proposal was used to approve (SECOP-1093). The marker
+   * lives in the same collection as request entries so the existing
+   * Firestore TTL policy on {@value #FIELD_EXPIRES_AT} reaps it — the
+   * expiry passed here must be the token expiry, since a marker is only
+   * meaningful while the token it blocks is still valid.
+   */
+  public @NotNull CompletableFuture<Void> markProposalConsumed(
+    @NotNull String consumptionKey,
+    @NotNull Instant expiresAt
+  ) {
+    return CompletableFutures.supplyAsync(() -> {
+      var doc = new HashMap<String, Object>();
+      doc.put(FIELD_EXPIRES_AT, Timestamp.ofTimeSecondsAndNanos(
+        expiresAt.getEpochSecond(),
+        expiresAt.getNano()));
+      doc.put(FIELD_CONSUMED, true);
+      try {
+        collection().document(consumptionKey).set(doc).get();
+      }
+      catch (InterruptedException | ExecutionException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(
+          "Failed to write proposal consumption marker " + consumptionKey, e);
+      }
+      return null;
     }, this.executor);
   }
 

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackMessages.java
@@ -167,6 +167,34 @@ final class SlackMessages {
   }
 
   /**
+   * Replaces the approver's OWN request DM after they approve
+   * (SECOP-1094). Without this the approver's message keeps its stale
+   * action link and nothing on their screen acknowledges the approval —
+   * in the picked-single-reviewer flow that reads as "did that even
+   * work?". The action link is removed, same as the sibling update.
+   */
+  static List<LayoutBlock> reviewerApprovedByYou(
+    @NotNull String requesterEmail,
+    @NotNull String groupId
+  ) {
+    return List.of(
+      HeaderBlock.builder()
+        .text(plain(":white_check_mark: You approved this request"))
+        .build(),
+      SectionBlock.builder()
+        .fields(List.of(
+          markdownField("*Requester*", "<mailto:" + requesterEmail + "|" + requesterEmail + ">"),
+          markdownField("*Group*", "`" + groupId + "`")
+        ))
+        .build(),
+      ContextBlock.builder()
+        .elements(List.of(markdown(
+          ":information_source: Nothing more to do — the requester has "
+            + "been notified.")))
+        .build());
+  }
+
+  /**
    * DM to the beneficiary confirming the activation completed.
    */
   static List<LayoutBlock> beneficiaryApproved(
@@ -200,6 +228,10 @@ final class SlackMessages {
 
   static String reviewerSiblingUpdateFallback(@NotNull String approverEmail) {
     return "Already approved by " + approverEmail + " — no action needed.";
+  }
+
+  static String reviewerApprovedByYouFallback(@NotNull String requesterEmail) {
+    return "You approved " + requesterEmail + "'s request — nothing more to do.";
   }
 
   static String beneficiaryApprovedFallback(@NotNull String groupId, @NotNull String approverEmail) {

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
@@ -12,6 +12,7 @@ package com.google.solutions.jitaccess.web.proposal;
 
 import com.google.common.base.Preconditions;
 import com.google.solutions.jitaccess.apis.Logger;
+import com.google.solutions.jitaccess.apis.clients.AccessDeniedException;
 import com.google.solutions.jitaccess.apis.clients.AccessException;
 import com.google.solutions.jitaccess.auth.EndUserId;
 import com.google.solutions.jitaccess.auth.GroupResolver;
@@ -442,6 +443,74 @@ public class SlackProposalHandler extends AbstractProposalHandler {
       "slack.onProposalApproved",
       "Updated %d reviewer DM(s) for approved request key=%s (approver=%s)",
       entriesOpt.get().size(), fp.key(), approverEmail);
+  }
+
+  /**
+   * SECOP-1093: reject approval links that were already used. Fail-open
+   * on Firestore errors — the JWT signature remains the authoritative
+   * authorization; consumption is anti-replay defense-in-depth, and an
+   * approval must not hard-depend on Firestore availability. Failures
+   * are logged at ERROR so an outage window (during which tokens
+   * temporarily regain the upstream replayable semantics) is visible.
+   */
+  @Override
+  public void verifyNotConsumed(@NotNull Proposal proposal)
+    throws AccessException {
+    var proposalId = proposal.id();
+    if (proposalId == null) {
+      // Proposal implementation without a stable id — nothing to check.
+      return;
+    }
+    boolean consumed;
+    try {
+      consumed = this.registry
+        .isProposalConsumed(this.registry.consumptionKey(proposalId))
+        .join();
+    }
+    catch (RuntimeException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
+      this.logger.error(
+        "slack.consumption.checkFailed",
+        "Failed to check proposal consumption for id=%s; allowing the "
+          + "approval (fail-open) — replay protection is degraded until "
+          + "Firestore recovers. cause=%s",
+        proposalId, cause.getMessage());
+      return;
+    }
+    if (consumed) {
+      throw new AccessDeniedException(
+        "This approval link has already been used. If further access is "
+          + "needed, ask the requester to submit a new request.");
+    }
+  }
+
+  /**
+   * SECOP-1093: record consumption after a successful approval.
+   * Best-effort by contract — the approval already succeeded, so a
+   * failed write only restores replayability for this one token; log
+   * loud and move on.
+   */
+  @Override
+  public void markConsumed(@NotNull Proposal proposal) {
+    var proposalId = proposal.id();
+    if (proposalId == null) {
+      return;
+    }
+    try {
+      this.registry
+        .markProposalConsumed(
+          this.registry.consumptionKey(proposalId),
+          proposal.expiry())
+        .join();
+    }
+    catch (RuntimeException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
+      this.logger.error(
+        "slack.consumption.markFailed",
+        "Failed to record proposal consumption for id=%s; this token "
+          + "remains replayable until it expires at %s. cause=%s",
+        proposalId, proposal.expiry(), cause.getMessage());
+    }
   }
 
   private void notifyBeneficiary(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/proposal/SlackProposalHandler.java
@@ -53,8 +53,10 @@ import java.util.concurrent.Semaphore;
  * <p>Flow on {@link #onProposalApproved}:
  * <ol>
  *   <li>Look up the registry entry by request key.
- *   <li>For each non-approver sibling, {@code chat.update} the original DM
- *       to "Already approved by X — no action needed".
+ *   <li>{@code chat.update} every recorded DM in place: non-approver
+ *       siblings get "Already approved by X — no action needed", the
+ *       approver's own message gets "You approved this request"
+ *       (SECOP-1094).
  *   <li>DM the beneficiary "Your elevation was approved by X".
  *   <li>Delete the registry entry.
  * </ol>
@@ -400,21 +402,29 @@ public class SlackProposalHandler extends AbstractProposalHandler {
     var siblingBlocks = SlackMessages.reviewerSiblingUpdate(
       fp.beneficiary(), fp.groupId(), approverEmail);
     var siblingFallback = SlackMessages.reviewerSiblingUpdateFallback(approverEmail);
+    // SECOP-1094: the approver's own DM gets a distinct "you approved
+    // this" update instead of being skipped — leaving it frozen (with a
+    // stale action link) reads as a failure, especially when the
+    // approver was the only recipient and no sibling update happens.
+    var approverBlocks = SlackMessages.reviewerApprovedByYou(
+      fp.beneficiary(), fp.groupId());
+    var approverFallback = SlackMessages.reviewerApprovedByYouFallback(fp.beneficiary());
 
     for (var entry : entriesOpt.get()) {
-      if (entry.email().equalsIgnoreCase(approverEmail)) {
-        // The approver doesn't need a "you approved" update — they did it.
-        continue;
-      }
+      var isApprover = entry.email().equalsIgnoreCase(approverEmail);
       try {
         this.slackClient.updateMessage(
-          entry.channelId(), entry.messageTs(), siblingBlocks, siblingFallback).join();
+          entry.channelId(),
+          entry.messageTs(),
+          isApprover ? approverBlocks : siblingBlocks,
+          isApprover ? approverFallback : siblingFallback).join();
       }
       catch (RuntimeException e) {
         var cause = e.getCause() != null ? e.getCause() : e;
         this.logger.warn(
           "slack.siblingUpdate.failed",
-          "Failed to chat.update sibling DM %s/%s for %s: %s",
+          "Failed to chat.update %s DM %s/%s for %s: %s",
+          isApprover ? "approver" : "sibling",
           entry.channelId(), entry.messageTs(), entry.email(), cause.getMessage());
       }
     }
@@ -430,8 +440,8 @@ public class SlackProposalHandler extends AbstractProposalHandler {
 
     this.logger.info(
       "slack.onProposalApproved",
-      "Updated %d sibling DM(s) for approved request key=%s (approver=%s)",
-      Math.max(0, entriesOpt.get().size() - 1), fp.key(), approverEmail);
+      "Updated %d reviewer DM(s) for approved request key=%s (approver=%s)",
+      entriesOpt.get().size(), fp.key(), approverEmail);
   }
 
   private void notifyBeneficiary(

--- a/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProposalResource.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/web/rest/ProposalResource.java
@@ -85,6 +85,11 @@ public class ProposalResource {
         proposal.group().environment().equals(environment),
         "The token must match the environment");
 
+      // SECOP-1093: an already-used approval link renders the same
+      // "URL no longer valid" banner as an expired one, instead of an
+      // approval page whose submit would then fail.
+      this.proposalHandler.verifyNotConsumed(proposal);
+
       return this.catalog
         .group(proposal.group())
         .map(grp -> ProposalInfo.create(
@@ -126,6 +131,11 @@ public class ProposalResource {
         groupId.environment().equals(environment),
         "The token must match the environment");
 
+      // SECOP-1093: proposal tokens approve exactly once. The check
+      // runs BEFORE the approval executes; the marker is written right
+      // after it succeeds.
+      this.proposalHandler.verifyNotConsumed(proposal);
+
       //
       // Attempt to approve.
       //
@@ -138,6 +148,7 @@ public class ProposalResource {
 
       var principal = approveOp.execute();
       this.auditTrail.joinExecuted(approveOp, principal);
+      this.proposalHandler.markConsumed(proposal);
 
       return ProposalInfo.create(
         group,

--- a/sources/src/main/resources/META-INF/resources/index.html
+++ b/sources/src/main/resources/META-INF/resources/index.html
@@ -745,7 +745,8 @@
                             <span class="jit-reviewer-picker-hint">
                                 — pick one or more teammates (those tagged
                                 <strong>team</strong> are likely on yours).
-                                Leave all unchecked to notify every qualified peer.
+                                Leave all unchecked to notify your closest
+                                qualified teammates automatically.
                             </span>
                         </div>
                         <input type="search"
@@ -779,10 +780,11 @@
                         .attr('name', 'selectedReviewers')
                         .attr('value', c.email || '');
                     // Default unchecked even for suggested. The picker is
-                    // an opt-in narrowing tool: an untouched form must
-                    // continue to mean "notify every qualified peer", same
-                    // as before the picker existed. The badge remains as
-                    // a visual hint of who likely makes a good reviewer.
+                    // an opt-in narrowing tool: an untouched form means
+                    // "let the server pick" — since SECOP-952 that is the
+                    // requester's closest teammates (small approver sets
+                    // still notify everyone). The badge remains a visual
+                    // hint of who likely makes a good reviewer.
                     const display = $('<span>')
                         .addClass('jit-reviewer-display')
                         .text(c.displayName || c.email || '');
@@ -852,8 +854,9 @@
                         .addClass('jit-reviewer-picker-hint')
                         .text(
                             'Couldn\'t load the list of qualified reviewers ' +
-                            '(Cloud Identity API hiccup). Submitting will fall ' +
-                            'back to notifying every qualified peer per the policy.'));
+                            '(Cloud Identity API hiccup). You can still submit — ' +
+                            'reviewers are chosen automatically server-side, or ' +
+                            'you may be asked to retry once suggestions are back.'));
                 form.append(notice);
             }
 

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestAbstractProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestAbstractProposalHandler.java
@@ -189,6 +189,24 @@ public class TestAbstractProposalHandler {
       () -> proposalHandler.accept("token"));
   }
 
+  /**
+   * SECOP-1093: accept() must surface the JWT jti as {@code Proposal.id()}
+   * so the consumption registry can key on it.
+   */
+  @Test
+  public void accept_exposesJwtIdAsProposalId() throws Exception {
+    var token = "{\"jti\":\"abc123\"," +
+      "\"rcp\":[\"user:user-2@example.com\"]," +
+      "\"grp\":\"jit-group:env.sys.group-1\"," +
+      "\"usr\":\"user:user-1@example.com\",\"inp\":{}}";
+
+    var signer = new PseudoSigner();
+    var proposalHandler = new SampleProposalHandler(signer);
+    var proposal = proposalHandler.accept(token);
+
+    assertEquals("abc123", proposal.id());
+  }
+
   @Test
   public void accept_whenInputEmpty() throws Exception {
     var token = "{\"rcp\":[\"user:user-2@example.com\",\"group:group@example.com\"]," +

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessageRegistry.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessageRegistry.java
@@ -70,6 +70,27 @@ public class TestSlackMessageRegistry {
         + "may iterate the recipients Set in different orders.");
   }
 
+  // -------------------------------------------------------------------------
+  // consumptionKey (SECOP-1093) — deterministic, salted, and namespaced
+  // away from request keys since both live in the same collection.
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void consumptionKey_isDeterministicAndSaltDependent() {
+    var registry = newRegistry(SALT_A);
+    assertEquals(
+      registry.consumptionKey("jti-1"),
+      registry.consumptionKey("jti-1"));
+    assertNotEquals(
+      registry.consumptionKey("jti-1"),
+      registry.consumptionKey("jti-2"));
+    assertNotEquals(
+      registry.consumptionKey("jti-1"),
+      newRegistry(SALT_B).consumptionKey("jti-1"),
+      "an attacker without the salt must not be able to precompute keys");
+    assertEquals(64, registry.consumptionKey("jti-1").length(), "HMAC-SHA-256 hex");
+  }
+
   @Test
   public void requestKey_distinguishesBeneficiary() {
     var registry = newRegistry(SALT_A);

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessages.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackMessages.java
@@ -163,6 +163,23 @@ public class TestSlackMessages {
   }
 
   // -------------------------------------------------------------------------
+  // reviewerApprovedByYou — replaces the approver's own DM (SECOP-1094).
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void reviewerApprovedByYou_dropsActionButtonAndNamesRequester() {
+    var blocks = SlackMessages.reviewerApprovedByYou(
+      "alice@example.com", "env/sys/grp");
+
+    assertFalse(blocks.stream().anyMatch(ActionsBlock.class::isInstance),
+      "the approver's post-approval message must not carry the action link");
+    var serialized = blocks.toString();
+    assertTrue(serialized.contains("alice@example.com"));
+    assertTrue(serialized.contains("env/sys/grp"));
+    assertTrue(serialized.contains("You approved"));
+  }
+
+  // -------------------------------------------------------------------------
   // beneficiaryApproved — confirms to requester that the elevation landed.
   // -------------------------------------------------------------------------
 
@@ -188,6 +205,8 @@ public class TestSlackMessages {
       .contains("alice@example.com"));
     assertTrue(SlackMessages.reviewerSiblingUpdateFallback("bob@example.com")
       .contains("bob@example.com"));
+    assertTrue(SlackMessages.reviewerApprovedByYouFallback("alice@example.com")
+      .contains("alice@example.com"));
     assertTrue(SlackMessages.beneficiaryApprovedFallback("env/sys/grp", "bob@example.com")
       .contains("env/sys/grp"));
   }

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
@@ -231,7 +231,7 @@ public class TestSlackProposalHandler {
   // -------------------------------------------------------------------------
 
   @Test
-  public void onProposalApproved_updatesSiblingsButNotApprover() throws Exception {
+  public void onProposalApproved_updatesSiblingsAndApproverDistinctly() throws Exception {
     var slack = slackClientHappyPath();
     var registry = mock(SlackMessageRegistry.class);
     var entries = List.of(
@@ -255,9 +255,18 @@ public class TestSlackProposalHandler {
       approval,
       proposalFor(ALICE, Set.<IamPrincipalId>of(BOB, CAROL)));
 
-    // Carol's DM gets updated; Bob's does NOT (he just approved).
-    verify(slack).updateMessage(eq("C-CAROL"), eq("222.222"), anyList(), anyString());
-    verify(slack, never()).updateMessage(eq("C-BOB"), anyString(), anyList(), anyString());
+    // Carol (sibling) gets the "already approved by X" update; Bob (the
+    // approver) gets the SECOP-1094 "you approved this" variant — both
+    // DMs are updated, with distinct fallback texts.
+    var carolFallback = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(slack).updateMessage(
+      eq("C-CAROL"), eq("222.222"), anyList(), carolFallback.capture());
+    assertTrue(carolFallback.getValue().contains("Already approved by bob@example.com"));
+
+    var bobFallback = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(slack).updateMessage(
+      eq("C-BOB"), eq("111.111"), anyList(), bobFallback.capture());
+    assertTrue(bobFallback.getValue().contains("You approved alice@example.com"));
 
     // Beneficiary (Alice) gets a confirmation DM.
     verify(slack).lookupUserByEmail(eq("alice@example.com"));
@@ -265,6 +274,40 @@ public class TestSlackProposalHandler {
 
     // Registry entry deleted after handling.
     verify(registry).delete(anyString());
+  }
+
+  /**
+   * SECOP-1094 regression: when the approver was the ONLY recipient
+   * (picked-single-reviewer flow), their DM previously received no
+   * update at all — which looked like the approval hadn't worked.
+   */
+  @Test
+  public void onProposalApproved_soleRecipientApproverStillGetsUpdate() throws Exception {
+    var slack = slackClientHappyPath();
+    var registry = mock(SlackMessageRegistry.class);
+    var entries = List.of(
+      new SlackMessageRegistry.ReviewerMessage(
+        "bob@example.com", "U-BOB", "C-BOB", "111.111"));
+    when(registry.requestKey(anyString(), anyString(), anyList()))
+      .thenReturn("test-fingerprint-key");
+    when(registry.lookup(anyString()))
+      .thenReturn(CompletableFuture.completedFuture(Optional.of(entries)));
+    when(registry.delete(anyString()))
+      .thenReturn(CompletableFuture.completedFuture(null));
+
+    var handler = newHandler(slack, registry, groupResolverPassthrough());
+
+    var approval = mock(JitGroupContext.ApprovalOperation.class);
+    when(approval.user()).thenReturn(BOB);
+
+    handler.onProposalApproved(
+      approval,
+      proposalFor(ALICE, Set.<IamPrincipalId>of(BOB)));
+
+    var fallback = org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(slack).updateMessage(
+      eq("C-BOB"), eq("111.111"), anyList(), fallback.capture());
+    assertTrue(fallback.getValue().contains("You approved alice@example.com"));
   }
 
   @Test

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/proposal/TestSlackProposalHandler.java
@@ -11,6 +11,7 @@
 package com.google.solutions.jitaccess.web.proposal;
 
 import com.google.solutions.jitaccess.apis.Logger;
+import com.google.solutions.jitaccess.apis.clients.AccessDeniedException;
 import com.google.solutions.jitaccess.auth.EndUserId;
 import com.google.solutions.jitaccess.auth.GroupResolver;
 import com.google.solutions.jitaccess.auth.IamPrincipalId;
@@ -377,6 +378,109 @@ public class TestSlackProposalHandler {
   // ---------------------------------------------------------------------
   // Options — fan-out concurrency cap (wavemm fork P1-4)
   // ---------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // verifyNotConsumed / markConsumed (SECOP-1093).
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void verifyNotConsumed_rejectsConsumedProposal() {
+    var registry = mock(SlackMessageRegistry.class);
+    when(registry.consumptionKey(eq("jti-1"))).thenReturn("consumption-key");
+    when(registry.isProposalConsumed(eq("consumption-key")))
+      .thenReturn(CompletableFuture.completedFuture(true));
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB));
+    when(proposal.id()).thenReturn("jti-1");
+
+    assertThrows(
+      AccessDeniedException.class,
+      () -> handler.verifyNotConsumed(proposal));
+  }
+
+  @Test
+  public void verifyNotConsumed_allowsFreshProposal() throws Exception {
+    var registry = mock(SlackMessageRegistry.class);
+    when(registry.consumptionKey(eq("jti-1"))).thenReturn("consumption-key");
+    when(registry.isProposalConsumed(eq("consumption-key")))
+      .thenReturn(CompletableFuture.completedFuture(false));
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB));
+    when(proposal.id()).thenReturn("jti-1");
+
+    handler.verifyNotConsumed(proposal);  // must not throw
+  }
+
+  @Test
+  public void verifyNotConsumed_skipsProposalsWithoutId() throws Exception {
+    var registry = mock(SlackMessageRegistry.class);
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    // proposalFor leaves Proposal#id unstubbed → null (no jti).
+    handler.verifyNotConsumed(proposalFor(ALICE, Set.<IamPrincipalId>of(BOB)));
+
+    verify(registry, never()).isProposalConsumed(anyString());
+  }
+
+  /**
+   * SECOP-1093: consumption is anti-replay defense-in-depth, not the
+   * authorization itself — a Firestore outage must not block approvals.
+   */
+  @Test
+  public void verifyNotConsumed_failsOpenOnRegistryError() throws Exception {
+    var registry = mock(SlackMessageRegistry.class);
+    when(registry.consumptionKey(anyString())).thenReturn("consumption-key");
+    when(registry.isProposalConsumed(anyString()))
+      .thenReturn(CompletableFuture.failedFuture(
+        new RuntimeException("firestore unavailable")));
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB));
+    when(proposal.id()).thenReturn("jti-1");
+
+    handler.verifyNotConsumed(proposal);  // must not throw
+  }
+
+  @Test
+  public void markConsumed_writesMarkerWithTokenExpiry() {
+    var registry = mock(SlackMessageRegistry.class);
+    when(registry.consumptionKey(eq("jti-1"))).thenReturn("consumption-key");
+    when(registry.markProposalConsumed(anyString(), any()))
+      .thenReturn(CompletableFuture.completedFuture(null));
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    var expiry = Instant.now().plus(Duration.ofHours(1));
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB));
+    when(proposal.id()).thenReturn("jti-1");
+    when(proposal.expiry()).thenReturn(expiry);
+
+    handler.markConsumed(proposal);
+
+    verify(registry).markProposalConsumed(eq("consumption-key"), eq(expiry));
+  }
+
+  @Test
+  public void markConsumed_swallowsRegistryErrors() {
+    var registry = mock(SlackMessageRegistry.class);
+    when(registry.consumptionKey(anyString())).thenReturn("consumption-key");
+    when(registry.markProposalConsumed(anyString(), any()))
+      .thenReturn(CompletableFuture.failedFuture(
+        new RuntimeException("firestore unavailable")));
+    var handler = newHandler(
+      slackClientHappyPath(), registry, groupResolverPassthrough());
+
+    var proposal = proposalFor(ALICE, Set.<IamPrincipalId>of(BOB));
+    when(proposal.id()).thenReturn("jti-1");
+
+    handler.markConsumed(proposal);  // must not throw
+  }
 
   @Test
   public void options_singleArgConstructor_appliesDefaultFanOutCap() {

--- a/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestProposalResource.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/web/rest/TestProposalResource.java
@@ -503,4 +503,113 @@ public class TestProposalResource {
         "token",
         new MultivaluedHashMap<>()));
   }
+
+  //---------------------------------------------------------------------------
+  // Single-use proposals (wavemm fork, SECOP-1093).
+  //---------------------------------------------------------------------------
+
+  /**
+   * SECOP-1093: an already-consumed token must be rejected BEFORE the
+   * approval executes — no membership, no audit event, no re-mark.
+   */
+  @Test
+  public void post_whenProposalAlreadyConsumed_rejectsBeforeApproving()
+    throws Exception {
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+
+    var resource = new ProposalResource();
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+    resource.proposalHandler = createProposalHandler(
+      group.id(),
+      new EndUserId("other@example.com"),
+      Set.of(SAMPLE_USER));
+    doThrow(new AccessDeniedException("This approval link has already been used"))
+      .when(resource.proposalHandler).verifyNotConsumed(any(Proposal.class));
+
+    assertThrows(
+      AccessDeniedException.class,
+      () -> resource.post(
+        group.id().environment(),
+        "token",
+        new MultivaluedHashMap<>()));
+
+    verify(resource.auditTrail, never()).joinExecuted(
+      any(JitGroupContext.ApprovalOperation.class),
+      any(Principal.class));
+    verify(resource.proposalHandler, never()).markConsumed(any(Proposal.class));
+  }
+
+  /**
+   * SECOP-1093: the happy path checks consumption before approving and
+   * records consumption only after the approval succeeded.
+   */
+  @Test
+  public void post_whenApprovalSucceeds_marksProposalConsumed()
+    throws Exception {
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+
+    var resource = new ProposalResource();
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+    resource.proposalHandler = createProposalHandler(
+      group.id(),
+      new EndUserId("other@example.com"),
+      Set.of(SAMPLE_USER));
+
+    resource.post(
+      group.id().environment(),
+      "token",
+      new MultivaluedHashMap<>());
+
+    var order = inOrder(resource.proposalHandler, resource.auditTrail);
+    order.verify(resource.proposalHandler).verifyNotConsumed(any(Proposal.class));
+    order.verify(resource.auditTrail).joinExecuted(
+      any(JitGroupContext.ApprovalOperation.class),
+      any(Principal.class));
+    order.verify(resource.proposalHandler).markConsumed(any(Proposal.class));
+  }
+
+  /**
+   * SECOP-1093: viewing an already-used link fails like an expired one,
+   * instead of rendering an approval page whose submit would then fail.
+   */
+  @Test
+  public void get_whenProposalAlreadyConsumed_rejects() throws Exception {
+    var group = Policies.createJitGroupPolicy(
+      "g-1",
+      new AccessControlList.Builder()
+        .allow(SAMPLE_USER, PolicyPermission.APPROVE_OTHERS.toMask())
+        .build(),
+      Map.of(Policy.ConstraintClass.JOIN, List.of(new ExpiryConstraint(Duration.ofMinutes(1)))));
+
+    var resource = new ProposalResource();
+    resource.logger = Mockito.mock(Logger.class);
+    resource.auditTrail = Mockito.mock(OperationAuditTrail.class);
+    resource.catalog = createCatalog(group);
+    resource.proposalHandler = createProposalHandler(
+      group.id(),
+      new EndUserId("other@example.com"),
+      Set.of(SAMPLE_USER));
+    doThrow(new AccessDeniedException("This approval link has already been used"))
+      .when(resource.proposalHandler).verifyNotConsumed(any(Proposal.class));
+
+    assertThrows(
+      AccessDeniedException.class,
+      () -> resource.get(
+        group.id().environment(),
+        "token"));
+  }
 }


### PR DESCRIPTION
Three follow-ups from the SECOP-952 live validation (2026-07-09), one commit each:

**SECOP-1093 — single-use approval JWTs** (security)
Approval links were replayable for the full ~1h token lifetime; each re-click re-granted a fresh membership window (observed live: a double-click re-elevated a lapsed 15-minute grant). Now: `Proposal.id()` surfaces the JWT `jti`; `ProposalHandler` gains `verifyNotConsumed`/`markConsumed` hooks (default no-op; Slack handler enforces via the existing Firestore registry — HMAC-keyed markers in the same collection, reaped by the existing `expires_at` TTL). `ProposalResource` checks on GET (used link → "URL no longer valid" banner) and POST (before the approval executes), records after success. **Fail-open on Firestore errors** with ERROR logs — the JWT stays authoritative; replay protection degrades rather than blocking approvals.

**SECOP-1094 — approver's own DM updates after approval** (UX)
The sibling-update loop skipped the approver, leaving their DM frozen with a stale action link — in the picked-single-reviewer flow nothing changed at all ("I'm not sure it really works though?"). Every recorded DM now updates in place: siblings get "already approved by X", the approver gets a new "✅ You approved this request" variant.

**SECOP-1095 — picker helper copy** (UX)
Three spots still described the pre-auto-narrow behavior ("leave all unchecked to notify every qualified peer"); updated to match SECOP-952 semantics.

Plus the `2.3.0-wavemm.9` version bump for the next release.

Tests: 13 new (consumption enforcement + fail-open, approver-DM variants incl. sole-recipient, jti round-trip, consumption-key properties); full suite 1030/1030 locally.

Deploys with the next wavemm-iam submodule bump — no infra changes needed (reuses the existing Firestore collection and TTL policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)